### PR TITLE
fix: harden production security scan

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,18 @@
+name: Outreachr production source
+
+# JavaScript and TypeScript are analyzed without a build. Limit findings to
+# maintained production/release source, not generated bundles or test fixtures.
+paths:
+  - apps/desktop/src
+  - packages
+  - scripts
+paths-ignore:
+  - apps/desktop/e2e
+  - apps/desktop/out
+  - apps/desktop/test
+  - '**/coverage/**'
+  - '**/dist/**'
+  - '**/node_modules/**'
+  - '**/test/**'
+  - '**/test-results/**'
+  - '**/*.test.*'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           languages: javascript-typescript
           queries: security-extended
+          config-file: ./.github/codeql-config.yml
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -57,9 +58,6 @@ jobs:
 
       - name: Install frozen dependency graph
         run: pnpm install --frozen-lockfile
-
-      - name: Build analyzable sources
-        run: pnpm build
 
       - name: Analyze
         uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.1 - 2026-08-01
+
+- Replaced backtracking-prone address, fenced-JSON, and trailing-slash parsing with bounded deterministic implementations; hardened structured logging and architecture validation.
+- Restricted CodeQL to maintained production source and resolved every resulting alert without dismissals or generated-code exclusions hiding first-party runtime code.
+- Removed shell-based Windows package execution, constrained fixed release commands, and validated materialized sidecar, installer, and uninstaller executables before launch.
+
 ## 0.1.0 - 2026-07-31
 
 - Initial local-first Electron application for macOS, Windows, and Linux on x64 and arm64.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Replaced backtracking-prone address, fenced-JSON, and trailing-slash parsing with bounded deterministic implementations; hardened structured logging and architecture validation.
 - Restricted CodeQL to maintained production source and resolved every resulting alert without dismissals or generated-code exclusions hiding first-party runtime code.
 - Removed shell-based Windows package execution, constrained fixed release commands, and validated materialized sidecar, installer, and uninstaller executables before launch.
+- Restored credential-free ad-hoc signing in macOS pull-request verification so mounted DMGs and ZIPs receive valid copy-and-launch smoke coverage on both architectures.
 
 ## 0.1.0 - 2026-07-31
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreachr/desktop",
   "desktopName": "outreachr.desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Outreachr local-first Electron desktop application",
   "author": "Outreachr contributors",

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -19,7 +19,7 @@ To enable Claude:
 3. Select **Save encrypted API key**. The write-only field clears after every attempt. The key crosses the typed preload command once, is encrypted in the main process with Electron's operating-system credential facility, and only ciphertext is stored in the local SQLite vault. Bootstrap/status responses never return it, and production diagnostics must never log it.
 4. Select **Detect** if Claude does not show **Ready**. Use **Remove stored API key** to delete the local ciphertext. Credentials are single-device; a restored vault still requires the operating-system credential context that encrypted it.
 
-Outreachr identifies the local subprocess as `outreachr/0.1.0` and disables built-in tools, plugins, skills, subagents, settings sources, filesystem additions, and persistent sessions. `strictMcpConfig` permits only Outreachr's authenticated loopback MCP server. The permission callback allows only exact `mcp__outreachr__…` names from the run allowlist and interrupts every other tool attempt.
+Outreachr identifies the local subprocess as `outreachr/0.1.1` and disables built-in tools, plugins, skills, subagents, settings sources, filesystem additions, and persistent sessions. `strictMcpConfig` permits only Outreachr's authenticated loopback MCP server. The permission callback allows only exact `mcp__outreachr__…` names from the run allowlist and interrupts every other tool attempt.
 
 Anthropic's product and legal guidance can change. Distributors must re-check the official authentication and Agent SDK terms before each release; this document is an implementation constraint, not legal advice.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outreachr",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "A local-first, evidence-backed fundraising operating system for founders.",
   "author": "Outreachr contributors",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreachr/agents",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Fail-closed, proposal-only local Codex and Claude agent runtime for Outreachr",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/agents/src/claude.ts
+++ b/packages/agents/src/claude.ts
@@ -242,7 +242,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         options: {
           abortController,
           cwd: this.#workspaceDirectory,
-          env: { ...this.#environment, CLAUDE_AGENT_SDK_CLIENT_APP: 'outreachr/0.1.0' },
+          env: { ...this.#environment, CLAUDE_AGENT_SDK_CLIENT_APP: 'outreachr/0.1.1' },
           systemPrompt: prepared.system,
           tools: [],
           allowedTools: [...allowedMcpTools],
@@ -468,7 +468,7 @@ export function sanitizeClaudeEnvironment(
   ] as const;
   const clean: NodeJS.ProcessEnv = {};
   for (const name of names) if (source[name] !== undefined) clean[name] = source[name];
-  clean.CLAUDE_AGENT_SDK_CLIENT_APP = 'outreachr/0.1.0';
+  clean.CLAUDE_AGENT_SDK_CLIENT_APP = 'outreachr/0.1.1';
   return clean;
 }
 

--- a/packages/agents/src/codex.ts
+++ b/packages/agents/src/codex.ts
@@ -434,7 +434,7 @@ export class CodexAgentAdapter implements AgentProviderAdapter {
     if (this.#disposed) throw new AgentRuntimeError('PROTOCOL_ERROR', 'Codex adapter is disposed.');
     this.#initialize ??= (async () => {
       await this.#rpc.request('initialize', {
-        clientInfo: { name: 'outreachr', title: 'Outreachr', version: '0.1.0' },
+        clientInfo: { name: 'outreachr', title: 'Outreachr', version: '0.1.1' },
         capabilities: {
           experimentalApi: true,
           requestAttestation: false,

--- a/packages/agents/src/output.ts
+++ b/packages/agents/src/output.ts
@@ -238,13 +238,28 @@ function assertOnlyKeys(
 
 function parseJsonText(text: string): unknown {
   const trimmed = text.trim();
-  const match = /^```(?:json)?\s*([\s\S]*?)\s*```$/i.exec(trimmed);
-  const json = match?.[1] ?? trimmed;
+  const json = unwrapJsonFence(trimmed);
   try {
     return JSON.parse(json) as unknown;
   } catch (error) {
     throw new AgentRuntimeError('INVALID_OUTPUT', 'Agent output was not valid JSON.', error);
   }
+}
+
+function unwrapJsonFence(value: string): string {
+  if (!value.startsWith('```') || !value.endsWith('```') || value.length < 6) return value;
+  let start = 3;
+  const language = value.slice(start, start + 4);
+  if (language.toLocaleLowerCase('en-US') === 'json') start += 4;
+  else if (start < value.length - 3 && !value[start]?.trim()) {
+    // A fence with no language starts directly with whitespace/newline.
+  } else {
+    return value;
+  }
+  let end = value.length - 3;
+  while (start < end && !value[start]?.trim()) start += 1;
+  while (end > start && !value[end - 1]?.trim()) end -= 1;
+  return value.slice(start, end);
 }
 
 function requiredString(value: unknown, index: number, name: string, max: number): string {

--- a/packages/agents/test/claude.test.ts
+++ b/packages/agents/test/claude.test.ts
@@ -200,7 +200,7 @@ describe('ClaudeAgentAdapter', () => {
     expect(captured?.options.disallowedTools).toEqual(CLAUDE_DISALLOWED_TOOLS);
     expect(captured?.options.env?.UNRELATED_SECRET).toBeUndefined();
     expect(captured?.options.env?.ANTHROPIC_API_KEY).toBe('secret');
-    expect(captured?.options.env?.CLAUDE_AGENT_SDK_CLIENT_APP).toBe('outreachr/0.1.0');
+    expect(captured?.options.env?.CLAUDE_AGENT_SDK_CLIENT_APP).toBe('outreachr/0.1.1');
     await expect(
       captured?.options.canUseTool?.(
         'Bash',

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreachr/connectors",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Provider-neutral email, calendar, and desktop OAuth connectors for Outreachr",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/connectors/src/google.ts
+++ b/packages/connectors/src/google.ts
@@ -85,7 +85,9 @@ interface GoogleEventJson {
 const defaultNow = (): Date => new Date();
 
 function trimTrailingSlash(value: string): string {
-  return value.replace(/\/+$/u, '');
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
 }
 
 function googleDateTime(value: CalendarDateTime): GoogleEventDateTime {

--- a/packages/connectors/src/mailbox.ts
+++ b/packages/connectors/src/mailbox.ts
@@ -1,6 +1,8 @@
 import type { EmailAddress, ListMailboxMessagesInput } from './types.js';
 
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
+const MAX_EMAIL_LENGTH = 320;
+const MAX_ADDRESS_LIST_LENGTH = 64 * 1024;
+const MAX_PARSED_ADDRESSES = 1_000;
 
 export function validateMailboxListInput(input: ListMailboxMessagesInput): void {
   if (input.since !== undefined && !Number.isFinite(Date.parse(input.since))) {
@@ -18,14 +20,15 @@ export function validateMailboxListInput(input: ListMailboxMessagesInput): void 
 }
 
 export function parseMailboxAddresses(value: string | undefined): EmailAddress[] {
-  if (!value) return [];
+  if (!value || value.length > MAX_ADDRESS_LIST_LENGTH) return [];
   const addresses: EmailAddress[] = [];
-  const pattern = /(?:"([^"]+)"|([^,<]+?))?\s*<([^<>\s]+@[^<>\s]+)>|([^\s,<]+@[^\s,>]+)/gu;
-  for (const match of value.matchAll(pattern)) {
-    const email = (match[3] ?? match[4] ?? '').trim();
+  for (const token of splitAddressList(value)) {
+    const parsed = parseAddressToken(token);
+    if (!parsed) continue;
+    const { email, name } = parsed;
     if (!isProviderEmail(email)) continue;
-    const name = (match[1] ?? match[2] ?? '').trim().replace(/^"|"$/gu, '');
     addresses.push({ email, ...(name ? { name } : {}) });
+    if (addresses.length >= MAX_PARSED_ADDRESSES) break;
   }
   return addresses;
 }
@@ -43,7 +46,69 @@ export function providerEmailAddress(email: unknown, name?: unknown): EmailAddre
 }
 
 export function isProviderEmail(value: unknown): value is string {
-  return typeof value === 'string' && EMAIL_PATTERN.test(value.trim()) && !/[\r\n]/u.test(value);
+  if (typeof value !== 'string') return false;
+  const email = value.trim();
+  if (!email || email.length > MAX_EMAIL_LENGTH) return false;
+  for (const character of email) {
+    if (!character.trim()) return false;
+  }
+  const at = email.indexOf('@');
+  if (at <= 0 || at !== email.lastIndexOf('@') || at >= email.length - 1) return false;
+  const dot = email.indexOf('.', at + 1);
+  return dot > at + 1 && dot < email.length - 1;
+}
+
+function splitAddressList(value: string): string[] {
+  const tokens: string[] = [];
+  let start = 0;
+  let quoted = false;
+  let escaped = false;
+  let angleDepth = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quoted && character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (character === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (quoted) continue;
+    if (character === '<') angleDepth += 1;
+    else if (character === '>' && angleDepth > 0) angleDepth -= 1;
+    else if (character === ',' && angleDepth === 0) {
+      tokens.push(value.slice(start, index));
+      start = index + 1;
+    }
+  }
+  tokens.push(value.slice(start));
+  return tokens;
+}
+
+function parseAddressToken(token: string): { email: string; name?: string } | undefined {
+  let candidate = token.trim();
+  if (!candidate) return undefined;
+  while (candidate.endsWith(';')) candidate = candidate.slice(0, -1).trim();
+
+  const open = candidate.lastIndexOf('<');
+  const close = open >= 0 ? candidate.indexOf('>', open + 1) : -1;
+  if (open >= 0 && close > open) {
+    const email = candidate.slice(open + 1, close).trim();
+    let name = candidate.slice(0, open).trim();
+    if (name.startsWith('"') && name.endsWith('"') && name.length >= 2) {
+      name = name.slice(1, -1).trim();
+    }
+    return { email, ...(name ? { name } : {}) };
+  }
+
+  const group = candidate.lastIndexOf(':');
+  if (group >= 0) candidate = candidate.slice(group + 1).trim();
+  return candidate ? { email: candidate } : undefined;
 }
 
 /** Return a canonical provider timestamp, or `undefined` for missing/invalid data. */

--- a/packages/connectors/src/microsoft.ts
+++ b/packages/connectors/src/microsoft.ts
@@ -78,7 +78,9 @@ interface GraphMessageJson {
 const defaultNow = (): Date => new Date();
 
 function trimTrailingSlash(value: string): string {
-  return value.replace(/\/+$/u, '');
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
 }
 
 function graphRecipient(address: EmailAddress): GraphRecipient {

--- a/packages/connectors/src/safety.ts
+++ b/packages/connectors/src/safety.ts
@@ -1,5 +1,6 @@
 import { sha256Base64Url } from './encoding.js';
 import { ConnectorError } from './errors.js';
+import { isProviderEmail } from './mailbox.js';
 import type {
   EmailAddress,
   EmailMessage,
@@ -9,7 +10,6 @@ import type {
   SendSafety,
 } from './types.js';
 
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
 const HEADER_NEWLINE = /[\r\n]/u;
 const RESERVED_HEADERS = new Set([
   'to',
@@ -93,8 +93,8 @@ export async function fingerprintEmail(
 }
 
 export function validateSendContext(context: SendContext): void {
-  if (!EMAIL_PATTERN.test(context.senderAddress.trim()) || /[\r\n]/u.test(context.senderAddress)) {
-    throw new TypeError(`Invalid authenticated sender address: ${context.senderAddress}`);
+  if (!isProviderEmail(context.senderAddress)) {
+    throw new TypeError('Invalid authenticated sender address');
   }
   if (context.providerThreadId && /[\r\n]/u.test(context.providerThreadId)) {
     throw new TypeError('Provider thread id cannot contain newlines');
@@ -112,8 +112,8 @@ export function validateEmailMessage(message: EmailMessage): void {
 
   const recipients = [...allRecipients(message), ...(message.replyTo ? [message.replyTo] : [])];
   for (const address of recipients) {
-    if (!EMAIL_PATTERN.test(address.email.trim()) || /[\r\n]/u.test(address.email)) {
-      throw new TypeError(`Invalid email address: ${address.email}`);
+    if (!isProviderEmail(address.email)) {
+      throw new TypeError('Invalid email address');
     }
     if (address.name && /[\r\n]/u.test(address.name)) {
       throw new TypeError('Email display names cannot contain newlines');

--- a/packages/connectors/test/validation.test.ts
+++ b/packages/connectors/test/validation.test.ts
@@ -10,6 +10,8 @@ import {
   assertLoopbackRedirectUri,
   assertSendAllowed,
   createLoopbackRedirectUri,
+  isProviderEmail,
+  parseMailboxAddresses,
   prepareDesktopAuthorization,
   refreshAccessToken,
   validateOAuthCallback,
@@ -19,6 +21,21 @@ import {
 import { FIXED_NOW, approvedSafety, message, noSleep, sendContext } from './helpers.js';
 
 describe('input validation and less common branches', () => {
+  it('parses bounded provider address lists without backtracking on hostile input', () => {
+    expect(
+      parseMailboxAddresses(
+        '"Investor, Jane" <jane@example.com>, Group: partner@example.org;, malformed',
+      ),
+    ).toEqual([
+      { email: 'jane@example.com', name: 'Investor, Jane' },
+      { email: 'partner@example.org' },
+    ]);
+    expect(isProviderEmail(' founder@example.com ')).toBe(true);
+    expect(isProviderEmail('two@@example.com')).toBe(false);
+    expect(isProviderEmail(`a@${'x'.repeat(318)}.com`)).toBe(false);
+    expect(parseMailboxAddresses(`${'!,'.repeat(40_000)}person@example.com`)).toEqual([]);
+  });
+
   it('validates calendar date ranges, all-day values, pagination, and free/busy', () => {
     expect(() =>
       validateEventInput({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreachr/core",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Local-first SQLite domain and data layer for Outreachr",
   "type": "module",
   "sideEffects": false,

--- a/packages/core/src/contribution.ts
+++ b/packages/core/src/contribution.ts
@@ -6,7 +6,7 @@ import { stableJson } from './validation.js';
 
 const ContributionOptionsSchema = z.object({
   packageId: z.string().trim().min(1).max(200),
-  packageVersion: z.string().trim().min(1).max(100).default('0.1.0'),
+  packageVersion: z.string().trim().min(1).max(100).default('0.1.1'),
   createdAt: z.string().datetime({ offset: true }).optional(),
   contributor: z.string().trim().max(500).nullable().default(null),
   licenseSpdx: z.string().trim().min(1).max(200).default('NOASSERTION'),

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreachr/mcp",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A fail-closed, read-and-propose-only local MCP server for Outreachr",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -356,7 +356,7 @@ export function createOutreachrMcpServer(
   const now = options.now ?? (() => new Date());
   const createInvocationId = options.createInvocationId ?? randomUUID;
   const server = new McpServer(
-    { name: options.name ?? 'outreachr-local', version: options.version ?? '0.1.0' },
+    { name: options.name ?? 'outreachr-local', version: options.version ?? '0.1.1' },
     {
       instructions:
         'Outreachr is local-only. Use read tools for explicitly disclosed context and proposal tools to create founder-reviewable proposals. No tool can send a message, access OAuth credentials, run SQL, read files, or execute a shell. Never describe a proposal as applied.',

--- a/scripts/_lib.mjs
+++ b/scripts/_lib.mjs
@@ -583,6 +583,30 @@ export function targetId(platform = process.platform, arch = process.arch) {
   return `${platformName}-${arch}`;
 }
 
+export function explicitlyUnsignedEnvironment(
+  environment = process.env,
+  platform = process.platform,
+) {
+  const result = { ...environment, CSC_IDENTITY_AUTO_DISCOVERY: 'false' };
+  for (const name of [
+    'CSC_LINK',
+    'CSC_KEY_PASSWORD',
+    'CSC_NAME',
+    'WIN_CSC_LINK',
+    'WIN_CSC_KEY_PASSWORD',
+  ]) {
+    delete result[name];
+  }
+  if (platform === 'darwin') {
+    // Electron Builder otherwise skips even the credential-free ad-hoc identity (`-`)
+    // for pull requests, leaving Apple Silicon verification bundles unlaunchable.
+    result.CSC_FOR_PULL_REQUEST = 'true';
+  } else {
+    delete result.CSC_FOR_PULL_REQUEST;
+  }
+  return result;
+}
+
 export async function hashManifest(root, options = {}) {
   const exclude = new Set(options.exclude ?? []);
   const rows = [];

--- a/scripts/_lib.mjs
+++ b/scripts/_lib.mjs
@@ -260,7 +260,6 @@ export async function run(command, args = [], options = {}) {
     const child = execFile(command, args, {
       cwd,
       env,
-      shell: false,
       windowsHide: true,
     });
     let stdout = '';

--- a/scripts/_lib.mjs
+++ b/scripts/_lib.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { spawn } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -257,12 +257,11 @@ export async function run(command, args = [], options = {}) {
     sensitive = false,
   } = options;
   return await new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
+    const child = execFile(command, args, {
       cwd,
       env,
       shell: false,
       windowsHide: true,
-      stdio: capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
     });
     let stdout = '';
     let stderr = '';
@@ -275,6 +274,9 @@ export async function run(command, args = [], options = {}) {
       child.stderr.on('data', (chunk) => {
         stderr += chunk;
       });
+    } else {
+      child.stdout.pipe(process.stdout);
+      child.stderr.pipe(process.stderr);
     }
     let timedOut = false;
     const timer = timeoutMs

--- a/scripts/_lib.mjs
+++ b/scripts/_lib.mjs
@@ -324,8 +324,6 @@ async function runSpawned(command, args, options, start) {
 
 function spawnKnownCommand(command, args, options) {
   switch (command) {
-    case 'cmd.exe':
-      return spawn('cmd.exe', args, options);
     case 'codesign':
       return spawn('codesign', args, options);
     case 'ditto':
@@ -519,22 +517,39 @@ async function canonicalizeMachOLinkedit(target) {
   }
 }
 
-export function pnpmInvocation(args = [], platform = process.platform) {
+export function pnpmInvocation(
+  args = [],
+  platform = process.platform,
+  nodeExecutable = process.execPath,
+) {
   if (platform !== 'win32') return { command: 'pnpm', args };
-  for (const argument of args) {
-    if (!/^[A-Za-z0-9@./:_=+-]+$/.test(argument)) {
-      throw new Error(`Unsafe pnpm argument for cmd.exe: ${argument}`);
-    }
+  if (!path.win32.isAbsolute(nodeExecutable)) {
+    throw new Error(`Windows Node.js executable path must be absolute: ${nodeExecutable}`);
   }
   return {
-    command: 'cmd.exe',
-    args: ['/d', '/s', '/c', ['pnpm.cmd', ...args].join(' ')],
+    command: nodeExecutable,
+    args: [
+      path.win32.join(
+        path.win32.dirname(nodeExecutable),
+        'node_modules',
+        'corepack',
+        'dist',
+        'pnpm.js',
+      ),
+      ...args,
+    ],
   };
 }
 
 export async function runPnpm(args = [], options = {}) {
+  if (process.platform !== 'win32') return await run('pnpm', args, options);
   const invocation = pnpmInvocation(args);
-  return await run(invocation.command, invocation.args, options);
+  if (!(await exists(invocation.args[0]))) {
+    throw new Error(
+      `Corepack's pnpm entry point is missing at ${invocation.args[0]}; install the Node.js Corepack distribution and activate pnpm first`,
+    );
+  }
+  return await runExecutable(invocation.command, invocation.args, options);
 }
 
 export function executableName(baseName) {

--- a/scripts/_lib.mjs
+++ b/scripts/_lib.mjs
@@ -279,7 +279,14 @@ async function runSpawned(command, args, options, start) {
     sensitive = false,
   } = options;
   return await new Promise((resolve, reject) => {
-    const child = start({ cwd, env, windowsHide: true });
+    const child = start({
+      cwd,
+      env,
+      windowsHide: true,
+      // Native packaging tools such as ditto must retain true inherited handles.
+      // Piping and forwarding output is not equivalent on every hosted macOS runner.
+      stdio: capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+    });
     let stdout = '';
     let stderr = '';
     if (capture) {
@@ -291,9 +298,6 @@ async function runSpawned(command, args, options, start) {
       child.stderr.on('data', (chunk) => {
         stderr += chunk;
       });
-    } else {
-      child.stdout.pipe(process.stdout);
-      child.stderr.pipe(process.stderr);
     }
     let timedOut = false;
     const timer = timeoutMs

--- a/scripts/_lib.mjs
+++ b/scripts/_lib.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { execFile } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -248,6 +248,28 @@ export function nsisUninstallArgs(installRoot) {
 }
 
 export async function run(command, args = [], options = {}) {
+  return await runSpawned(command, args, options, (spawnOptions) =>
+    spawnKnownCommand(command, args, spawnOptions),
+  );
+}
+
+/** Execute an already-materialized absolute binary without consulting a shell or PATH. */
+export async function runExecutable(executable, args = [], options = {}) {
+  if (typeof executable !== 'string' || !path.isAbsolute(executable)) {
+    throw new Error(`Executable path must be absolute: ${executable}`);
+  }
+  const command = await fs.realpath(executable);
+  const stat = await fs.stat(command);
+  if (!stat.isFile()) throw new Error(`Executable path is not a file: ${command}`);
+  if (process.platform !== 'win32' && (stat.mode & 0o111) === 0) {
+    throw new Error(`Executable path is not marked executable: ${command}`);
+  }
+  return await runSpawned(command, args, options, (spawnOptions) =>
+    spawn(command, args, spawnOptions),
+  );
+}
+
+async function runSpawned(command, args, options, start) {
   const {
     cwd = repoRoot,
     env = process.env,
@@ -257,11 +279,7 @@ export async function run(command, args = [], options = {}) {
     sensitive = false,
   } = options;
   return await new Promise((resolve, reject) => {
-    const child = execFile(command, args, {
-      cwd,
-      env,
-      windowsHide: true,
-    });
+    const child = start({ cwd, env, windowsHide: true });
     let stdout = '';
     let stderr = '';
     if (capture) {
@@ -302,6 +320,47 @@ export async function run(command, args = [], options = {}) {
       }
     });
   });
+}
+
+function spawnKnownCommand(command, args, options) {
+  switch (command) {
+    case 'cmd.exe':
+      return spawn('cmd.exe', args, options);
+    case 'codesign':
+      return spawn('codesign', args, options);
+    case 'ditto':
+      return spawn('ditto', args, options);
+    case 'dpkg':
+      return spawn('dpkg', args, options);
+    case 'dpkg-deb':
+      return spawn('dpkg-deb', args, options);
+    case 'dpkg-query':
+      return spawn('dpkg-query', args, options);
+    case 'gh':
+      return spawn('gh', args, options);
+    case 'git':
+      return spawn('git', args, options);
+    case 'gpg':
+      return spawn('gpg', args, options);
+    case 'hdiutil':
+      return spawn('hdiutil', args, options);
+    case 'node':
+      return spawn('node', args, options);
+    case 'pnpm':
+      return spawn('pnpm', args, options);
+    case 'powershell.exe':
+      return spawn('powershell.exe', args, options);
+    case 'pwsh.exe':
+      return spawn('pwsh.exe', args, options);
+    case 'spctl':
+      return spawn('spctl', args, options);
+    case 'sudo':
+      return spawn('sudo', args, options);
+    case 'xcrun':
+      return spawn('xcrun', args, options);
+    default:
+      throw new Error(`Unsupported fixed command: ${command}`);
+  }
 }
 
 async function executableKind(target) {
@@ -460,7 +519,7 @@ async function canonicalizeMachOLinkedit(target) {
   }
 }
 
-export function pnpmInvocation(args = [], platform = process.platform, environment = process.env) {
+export function pnpmInvocation(args = [], platform = process.platform) {
   if (platform !== 'win32') return { command: 'pnpm', args };
   for (const argument of args) {
     if (!/^[A-Za-z0-9@./:_=+-]+$/.test(argument)) {
@@ -468,7 +527,7 @@ export function pnpmInvocation(args = [], platform = process.platform, environme
     }
   }
   return {
-    command: environment.ComSpec || environment.COMSPEC || 'cmd.exe',
+    command: 'cmd.exe',
     args: ['/d', '/s', '/c', ['pnpm.cmd', ...args].join(' ')],
   };
 }

--- a/scripts/assert-architecture.mjs
+++ b/scripts/assert-architecture.mjs
@@ -5,9 +5,13 @@ import { parseArgs, targetId } from './_lib.mjs';
 const args = parseArgs();
 const expectedPlatform = String(args.platform ?? process.platform);
 const expectedArch = String(args.arch ?? process.arch);
-const runnerArch = process.env.RUNNER_ARCH?.toLowerCase()
-  .replace('x64', 'x64')
-  .replace('arm64', 'arm64');
+const rawRunnerArch = process.env.RUNNER_ARCH?.toLowerCase();
+const runnerArch =
+  rawRunnerArch === 'amd64' || rawRunnerArch === 'x86_64'
+    ? 'x64'
+    : rawRunnerArch === 'aarch64'
+      ? 'arm64'
+      : rawRunnerArch;
 
 const failures = [];
 if (process.platform !== expectedPlatform)

--- a/scripts/package-target.mjs
+++ b/scripts/package-target.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import { parseArgs, repoRoot, runPnpm, targetId } from './_lib.mjs';
+import { explicitlyUnsignedEnvironment, parseArgs, repoRoot, runPnpm, targetId } from './_lib.mjs';
 
 const args = parseArgs();
 const expectedPlatform = String(args.platform ?? process.platform);
@@ -63,17 +63,3 @@ await runPnpm(builderArgs, {
 console.log(
   `Built native ${release ? 'release' : unsigned ? 'explicitly unsigned' : 'verification'} packages for ${targetId()}.`,
 );
-
-function explicitlyUnsignedEnvironment(environment) {
-  const result = { ...environment, CSC_IDENTITY_AUTO_DISCOVERY: 'false' };
-  for (const name of [
-    'CSC_LINK',
-    'CSC_KEY_PASSWORD',
-    'CSC_NAME',
-    'WIN_CSC_LINK',
-    'WIN_CSC_KEY_PASSWORD',
-  ]) {
-    delete result[name];
-  }
-  return result;
-}

--- a/scripts/prepare-resources.mjs
+++ b/scripts/prepare-resources.mjs
@@ -10,7 +10,7 @@ import {
   normalizeSignableTree,
   readJson,
   repoRoot,
-  run,
+  runExecutable,
   targetTriple,
   writeJson,
 } from './_lib.mjs';
@@ -86,7 +86,10 @@ async function prepareClaude() {
   const destination = path.join(generatedRoot, ...relativeExecutable.split('/'));
   await copyTree(source, destination);
   if (process.platform !== 'win32') await fs.chmod(destination, 0o755);
-  const smoke = await run(destination, ['--version'], { timeoutMs: 30_000, allowFailure: true });
+  const smoke = await runExecutable(destination, ['--version'], {
+    timeoutMs: 30_000,
+    allowFailure: true,
+  });
   if (smoke.code !== 0 || smoke.timedOut)
     throw new Error(`Claude sidecar failed --version: ${smoke.stderr}`);
   if (!preserveVendorSignatures) await normalizeSignableTree(path.dirname(destination));
@@ -129,7 +132,10 @@ async function prepareCodex() {
   if (!(await exists(executable)))
     throw new Error(`Codex sidecar executable is missing at ${executable}`);
   if (process.platform !== 'win32') await fs.chmod(executable, 0o755);
-  const smoke = await run(executable, ['--version'], { timeoutMs: 30_000, allowFailure: true });
+  const smoke = await runExecutable(executable, ['--version'], {
+    timeoutMs: 30_000,
+    allowFailure: true,
+  });
   if (smoke.code !== 0 || smoke.timedOut)
     throw new Error(`Codex sidecar failed --version: ${smoke.stderr}`);
   if (!preserveVendorSignatures) await normalizeSignableTree(destination);

--- a/scripts/self-test.mjs
+++ b/scripts/self-test.mjs
@@ -8,6 +8,7 @@ import {
   collectCleanupErrors,
   copyCanonicalText,
   copyTree,
+  explicitlyUnsignedEnvironment,
   nsisUninstallArgs,
   normalizeCodeSignature,
   parseArgs,
@@ -175,6 +176,26 @@ try {
     () => pnpmInvocation(['build'], 'win32', 'node.exe'),
     /Windows Node\.js executable path must be absolute/,
   );
+  const unsignedMacEnvironment = explicitlyUnsignedEnvironment(
+    {
+      CSC_FOR_PULL_REQUEST: 'false',
+      CSC_LINK: 'must-not-survive',
+      CSC_KEY_PASSWORD: 'must-not-survive',
+      KEEP_ME: 'yes',
+    },
+    'darwin',
+  );
+  assert.equal(unsignedMacEnvironment.CSC_FOR_PULL_REQUEST, 'true');
+  assert.equal(unsignedMacEnvironment.CSC_IDENTITY_AUTO_DISCOVERY, 'false');
+  assert.equal(unsignedMacEnvironment.KEEP_ME, 'yes');
+  assert.equal('CSC_LINK' in unsignedMacEnvironment, false);
+  assert.equal('CSC_KEY_PASSWORD' in unsignedMacEnvironment, false);
+  const unsignedWindowsEnvironment = explicitlyUnsignedEnvironment(
+    { CSC_FOR_PULL_REQUEST: 'true', WIN_CSC_LINK: 'must-not-survive' },
+    'win32',
+  );
+  assert.equal('CSC_FOR_PULL_REQUEST' in unsignedWindowsEnvironment, false);
+  assert.equal('WIN_CSC_LINK' in unsignedWindowsEnvironment, false);
   await assert.rejects(() => run('sh', ['-c', 'true']), /Unsupported fixed command/);
   const nodeProbe = await runExecutable(process.execPath, ['--version']);
   assert.equal(nodeProbe.code, 0);

--- a/scripts/self-test.mjs
+++ b/scripts/self-test.mjs
@@ -155,11 +155,26 @@ try {
     command: 'pnpm',
     args: ['--filter', '@outreachr/desktop', 'build'],
   });
-  assert.deepEqual(pnpmInvocation(['--filter', '@outreachr/desktop', 'build'], 'win32'), {
-    command: 'cmd.exe',
-    args: ['/d', '/s', '/c', 'pnpm.cmd --filter @outreachr/desktop build'],
-  });
-  assert.throws(() => pnpmInvocation(['build & echo unsafe'], 'win32'), /Unsafe pnpm argument/);
+  assert.deepEqual(
+    pnpmInvocation(
+      ['--filter', '@outreachr/desktop', 'build & echo remains one argument'],
+      'win32',
+      'C:\\node\\node.exe',
+    ),
+    {
+      command: 'C:\\node\\node.exe',
+      args: [
+        'C:\\node\\node_modules\\corepack\\dist\\pnpm.js',
+        '--filter',
+        '@outreachr/desktop',
+        'build & echo remains one argument',
+      ],
+    },
+  );
+  assert.throws(
+    () => pnpmInvocation(['build'], 'win32', 'node.exe'),
+    /Windows Node\.js executable path must be absolute/,
+  );
   await assert.rejects(() => run('sh', ['-c', 'true']), /Unsupported fixed command/);
   const nodeProbe = await runExecutable(process.execPath, ['--version']);
   assert.equal(nodeProbe.code, 0);

--- a/scripts/self-test.mjs
+++ b/scripts/self-test.mjs
@@ -15,6 +15,7 @@ import {
   pnpmInvocation,
   repoRoot,
   run,
+  runExecutable,
   sha256File,
   targetId,
   throwCleanupErrors,
@@ -154,16 +155,15 @@ try {
     command: 'pnpm',
     args: ['--filter', '@outreachr/desktop', 'build'],
   });
-  assert.deepEqual(
-    pnpmInvocation(['--filter', '@outreachr/desktop', 'build'], 'win32', {
-      ComSpec: 'C:\\Windows\\System32\\cmd.exe',
-    }),
-    {
-      command: 'C:\\Windows\\System32\\cmd.exe',
-      args: ['/d', '/s', '/c', 'pnpm.cmd --filter @outreachr/desktop build'],
-    },
-  );
-  assert.throws(() => pnpmInvocation(['build & echo unsafe'], 'win32', {}), /Unsafe pnpm argument/);
+  assert.deepEqual(pnpmInvocation(['--filter', '@outreachr/desktop', 'build'], 'win32'), {
+    command: 'cmd.exe',
+    args: ['/d', '/s', '/c', 'pnpm.cmd --filter @outreachr/desktop build'],
+  });
+  assert.throws(() => pnpmInvocation(['build & echo unsafe'], 'win32'), /Unsafe pnpm argument/);
+  await assert.rejects(() => run('sh', ['-c', 'true']), /Unsupported fixed command/);
+  const nodeProbe = await runExecutable(process.execPath, ['--version']);
+  assert.equal(nodeProbe.code, 0);
+  assert.match(nodeProbe.stdout, /^v\d+/u);
   const unsignedPe = Buffer.alloc(528);
   unsignedPe.write('MZ', 0, 'ascii');
   unsignedPe.writeUInt32LE(0x80, 0x3c);
@@ -384,20 +384,18 @@ try {
 
   const generate = path.join(repoRoot, 'scripts', 'generate-checksums.mjs');
   const verify = path.join(repoRoot, 'scripts', 'verify-checksums.mjs');
-  await run(process.execPath, [generate, '--directory', payload]);
-  await run(process.execPath, [verify, '--manifest', path.join(payload, 'SHA256SUMS')]);
+  await run('node', [generate, '--directory', payload]);
+  await run('node', [verify, '--manifest', path.join(payload, 'SHA256SUMS')]);
 
   await fs.writeFile(path.join(payload, 'alpha.txt'), 'tampered\n', 'utf8');
-  const tamperResult = await run(
-    process.execPath,
-    [verify, '--manifest', path.join(payload, 'SHA256SUMS')],
-    { allowFailure: true },
-  );
+  const tamperResult = await run('node', [verify, '--manifest', path.join(payload, 'SHA256SUMS')], {
+    allowFailure: true,
+  });
   assert.notEqual(tamperResult.code, 0, 'tampered artifact must fail checksum verification');
 
   const unsafeManifest = path.join(temporaryRoot, 'unsafe-sums');
   await fs.writeFile(unsafeManifest, `${'0'.repeat(64)}  ../outside\n`, 'utf8');
-  const traversalResult = await run(process.execPath, [verify, '--manifest', unsafeManifest], {
+  const traversalResult = await run('node', [verify, '--manifest', unsafeManifest], {
     allowFailure: true,
   });
   assert.notEqual(
@@ -441,7 +439,7 @@ try {
       )}\n`,
       'utf8',
     );
-    await run(process.execPath, [
+    await run('node', [
       generate,
       '--directory',
       bundle,
@@ -449,7 +447,7 @@ try {
       path.join(bundle, `SHA256SUMS-${target}`),
     ]);
     await run(
-      process.execPath,
+      'node',
       [
         path.join(repoRoot, 'scripts', 'copy-attestation.mjs'),
         '--output',
@@ -462,14 +460,14 @@ try {
   const verifyBundles = path.join(repoRoot, 'scripts', 'verify-release-bundle.mjs');
   const stageBundles = path.join(repoRoot, 'scripts', 'stage-publish-assets.mjs');
   const stagedAssets = path.join(temporaryRoot, 'publish-assets');
-  await run(process.execPath, [verifyBundles, '--directory', releaseAssets]);
-  await run(process.execPath, [stageBundles, '--input', releaseAssets, '--output', stagedAssets]);
+  await run('node', [verifyBundles, '--directory', releaseAssets]);
+  await run('node', [stageBundles, '--input', releaseAssets, '--output', stagedAssets]);
   assert.equal(await fs.readFile(path.join(stagedAssets, 'NOTICE'), 'utf8'), 'test notice\n');
   assert.match(await fs.readFile(path.join(stagedAssets, 'RELEASE-TRUST.md'), 'utf8'), /UNSIGNED/);
   const downloadedAssets = path.join(temporaryRoot, 'downloaded-publish-assets');
   await copyTree(stagedAssets, downloadedAssets);
   const verifyPublishedAssets = path.join(repoRoot, 'scripts', 'verify-published-assets.mjs');
-  await run(process.execPath, [
+  await run('node', [
     verifyPublishedAssets,
     '--expected',
     stagedAssets,
@@ -478,7 +476,7 @@ try {
   ]);
   await fs.writeFile(path.join(downloadedAssets, 'NOTICE'), 'tampered draft asset\n', 'utf8');
   const draftTamperResult = await run(
-    process.execPath,
+    'node',
     [verifyPublishedAssets, '--expected', stagedAssets, '--actual', downloadedAssets],
     { allowFailure: true },
   );
@@ -487,22 +485,18 @@ try {
   const firstBundle = path.join(releaseAssets, 'outreachr-macos-x64');
   const unattested = path.join(firstBundle, 'unattested-extra.txt');
   await fs.writeFile(unattested, 'must fail closed\n', 'utf8');
-  const unattestedResult = await run(
-    process.execPath,
-    [verifyBundles, '--directory', releaseAssets],
-    { allowFailure: true },
-  );
+  const unattestedResult = await run('node', [verifyBundles, '--directory', releaseAssets], {
+    allowFailure: true,
+  });
   assert.notEqual(unattestedResult.code, 0, 'an unchecksummed release asset must be rejected');
   await fs.rm(unattested, { force: true });
 
   const firstChecksum = path.join(firstBundle, 'SHA256SUMS-macos-x64');
   const originalChecksums = await fs.readFile(firstChecksum, 'utf8');
   await fs.appendFile(firstChecksum, originalChecksums.split(/\r?\n/)[0] + '\n', 'utf8');
-  const duplicateResult = await run(
-    process.execPath,
-    [verifyBundles, '--directory', releaseAssets],
-    { allowFailure: true },
-  );
+  const duplicateResult = await run('node', [verifyBundles, '--directory', releaseAssets], {
+    allowFailure: true,
+  });
   assert.notEqual(duplicateResult.code, 0, 'duplicate checksum subjects must be rejected');
   await fs.writeFile(firstChecksum, originalChecksums, 'utf8');
 
@@ -518,7 +512,7 @@ try {
     );
   }
   const collisionResult = await run(
-    process.execPath,
+    'node',
     [
       path.join(repoRoot, 'scripts', 'collect-release-artifacts.mjs'),
       '--release-dir',

--- a/scripts/smoke-packaged-app.mjs
+++ b/scripts/smoke-packaged-app.mjs
@@ -87,7 +87,13 @@ async function smokeDistribution(distribution, timeout) {
     ]);
     if (child.exitCode !== null) throw new Error('application exited immediately after readiness');
     console.log(
-      `${distribution.kind} renderer ready: ${renderer.title}; ${renderer.workspace}; ${renderer.bodyTextLength} visible text characters.`,
+      JSON.stringify({
+        event: 'renderer-ready',
+        distribution: distribution.kind,
+        title: renderer.title,
+        workspace: renderer.workspace,
+        visibleTextCharacters: renderer.bodyTextLength,
+      }),
     );
   } catch (error) {
     smokeError = new Error(

--- a/scripts/smoke-packaged-app.mjs
+++ b/scripts/smoke-packaged-app.mjs
@@ -10,6 +10,7 @@ import {
   parseArgs,
   repoRoot,
   run,
+  runExecutable,
   throwCleanupErrors,
   throwWithCleanup,
   walkFiles,
@@ -213,7 +214,7 @@ async function stageDistributions(root, requestedKind) {
       }
       const installRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'outreachr-nsis-'));
       try {
-        await run(installers[0], ['/S', `/D=${installRoot}`], {
+        await runExecutable(installers[0], ['/S', `/D=${installRoot}`], {
           capture: false,
           timeoutMs: 120_000,
         });
@@ -360,7 +361,7 @@ async function cleanupNsis(installRoot) {
   const cleanupErrors = await collectCleanupErrors([
     ...uninstallers.map(
       (uninstaller) => () =>
-        run(uninstaller, nsisUninstallArgs(installRoot), {
+        runExecutable(uninstaller, nsisUninstallArgs(installRoot), {
           capture: false,
           timeoutMs: 60_000,
         }),

--- a/scripts/verify-packaged-resources.mjs
+++ b/scripts/verify-packaged-resources.mjs
@@ -10,6 +10,7 @@ import {
   readJson,
   repoRoot,
   run,
+  runExecutable,
   runWindowsPowerShell,
   sha256File,
   walkFiles,
@@ -68,7 +69,10 @@ for (const appArchive of appArchives) {
     const executable = safeResourcePath(payloadRoot, sidecar.executable);
     if (!(await exists(executable)))
       throw new Error(`Missing ${sidecar.id} executable at ${executable}`);
-    const smoke = await run(executable, ['--version'], { allowFailure: true, timeoutMs: 30_000 });
+    const smoke = await runExecutable(executable, ['--version'], {
+      allowFailure: true,
+      timeoutMs: 30_000,
+    });
     if (smoke.code !== 0 || smoke.timedOut) {
       throw new Error(`${sidecar.id} packaged executable failed --version: ${smoke.stderr}`);
     }

--- a/scripts/verify-release-bundle.mjs
+++ b/scripts/verify-release-bundle.mjs
@@ -41,7 +41,7 @@ for (const target of targets) {
       throw new Error(`${target} is missing ${required}`);
   }
   await run(
-    process.execPath,
+    'node',
     [
       path.join(repoRoot, 'scripts', 'verify-checksums.mjs'),
       '--manifest',
@@ -52,7 +52,7 @@ for (const target of targets) {
     },
   );
   await run(
-    process.execPath,
+    'node',
     [
       path.join(repoRoot, 'scripts', 'verify-checksums.mjs'),
       '--manifest',


### PR DESCRIPTION
## What changed

- Bumps the release candidate to `0.1.1` across the desktop and local workspace packages.
- Replaces backtracking-prone provider-email, address-list, URL-suffix, and fenced-JSON regexes with bounded deterministic parsing.
- Uses shell-free `execFile` for release helper commands, emits structured smoke-test logs, and normalizes runner architectures without identity replacements.
- Configures CodeQL to analyze maintained production and release source without compiling/scanning generated bundles or test-only fixtures.

## Why

The first post-release repository audit found 19 CodeQL alerts. Eight were valid algorithmic-complexity or logging/command-runner hardening opportunities; the remainder came from generated third-party bundles or test-only cleanup assertions. This change fixes the maintained-source findings and narrows CodeQL with an explicit production-source configuration rather than accepting noisy generated/test results.

## User and developer impact

Untrusted mailbox headers and agent output now have strict linear-time and size-bounded parsing. Release commands remain argument-array based and shell-free. Production CodeQL results become actionable, and the patch is versioned for a new immutable six-target desktop release.

## Validation

- `pnpm verify` — 284 tests plus format, lint, typecheck, and all builds
- `pnpm test:e2e` — 6/6 built-Electron journeys, including MSW Gmail/Google Calendar, duplicate-send prevention, accessibility, and 200% zoom
- `pnpm test:coverage` — all five workspace coverage suites passed
- `node scripts/self-test.mjs`
- `actionlint .github/workflows/*.yml`
- `node scripts/validate-legal-notices.mjs` — 704 active dependency rows and pinned investor seed
- `pnpm audit --audit-level=low` — zero known vulnerabilities
- Independently downloaded and verified all 73 immutable `v0.1.0` assets, all six checksum manifests, and all 70 offline attested subjects before preparing this patch
