### PR TITLE
fix(desktop): pin app-shell grid row so main content scrolls vertically

### DIFF
--- a/apps/desktop/e2e/main-content-scroll.e2e.spec.ts
+++ b/apps/desktop/e2e/main-content-scroll.e2e.spec.ts
@@ -1,0 +1,49 @@
+import { completeOnboarding, expect, navigate, test } from './fixtures';
+
+test.describe('Main content scrolling', () => {
+  test('a long page scrolls vertically with the wheel instead of overflowing the window', async ({
+    page,
+  }) => {
+    await completeOnboarding(page);
+    await navigate(page, 'Investors');
+    await page.waitForTimeout(1500);
+
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+
+    // The shell must stay pinned to the window. Regression guard for the
+    // app-shell grid row being auto-sized, which let #main-content grow to the
+    // full content height (~18000px) so it never became a scroll container and
+    // vertical wheel scrolling did nothing.
+    const layout = await page.evaluate(() => {
+      const main = document.getElementById('main-content')!;
+      const shell = document.querySelector('.app-shell') as HTMLElement;
+      return {
+        shellHeight: shell.offsetHeight,
+        mainHeight: main.offsetHeight,
+        clientHeight: main.clientHeight,
+        scrollHeight: main.scrollHeight,
+      };
+    });
+
+    expect(layout.shellHeight).toBeLessThanOrEqual(viewportHeight);
+    expect(
+      layout.mainHeight,
+      'main-content must stay within the window rather than growing to fit its content',
+    ).toBeLessThanOrEqual(viewportHeight);
+    expect(
+      layout.scrollHeight,
+      'the Investors page should have more content than fits on screen',
+    ).toBeGreaterThan(layout.clientHeight);
+
+    const rect = await page.evaluate(() => {
+      const r = document.getElementById('main-content')!.getBoundingClientRect();
+      return { x: r.x, y: r.y, w: r.width, h: r.height };
+    });
+    await page.mouse.move(rect.x + rect.w / 2, rect.y + rect.h / 2);
+    await page.mouse.wheel(0, 500);
+    await page.waitForTimeout(1200); // scroll-behavior: smooth needs settling time
+
+    const scrollTop = await page.evaluate(() => document.getElementById('main-content')!.scrollTop);
+    expect(scrollTop, 'a vertical wheel gesture must scroll the main content').toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/global.css
+++ b/apps/desktop/src/renderer/src/styles/global.css
@@ -287,6 +287,7 @@ p {
 .app-shell {
   display: grid;
   grid-template-columns: 248px minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
   width: 100%;
   height: 100%;
   background: var(--bg);


### PR DESCRIPTION
## Problem

On Windows, vertical scrolling does nothing in the main content area. Horizontal scrolling works, which makes it look like a trackpad or input issue rather than a layout one.

## Cause

`.app-shell` declares `grid-template-columns` but no `grid-template-rows`, so its single implicit row is auto-sized by its content. On a long page such as Investors the row grows to ~18370px inside a 940px window, and `#main-content` grows with it to ~18322px.

Because the element's height matches its own content height, `scrollHeight === clientHeight` and it never becomes a scroll container. Vertical wheel events have nothing to scroll, and the overflow is clipped by the `overflow: hidden` on `html, body, #root`.

Horizontal scrolling still appears to work because `.data-table-wrap` is its own, correctly constrained, scroll container.

## Fix

Pin the row with `grid-template-rows: minmax(0, 1fr)` — the idiom already used for the columns and in `.workspace`.

Measured after the change: shell 940px, main content 892px (940 minus the 48px workspace bar), and a wheel gesture scrolls as expected.

## Testing

- `pnpm verify` — passes (294 tests, lint, typecheck, build)
- `pnpm test:e2e` — 7 passed, including a new regression test asserting the main content stays within the viewport and scrolls in response to a wheel gesture
- Reproduced and verified on Windows 11, Electron 43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
