### PR TITLE
fix(desktop): guard theme localStorage access against non-functional Storage

### DIFF
--- a/apps/desktop/src/renderer/src/lib/theme.ts
+++ b/apps/desktop/src/renderer/src/lib/theme.ts
@@ -1,0 +1,20 @@
+export type Theme = 'light' | 'dark' | 'system';
+
+const THEME_STORAGE_KEY = 'outreachr.theme';
+
+export function getStoredTheme(): Theme {
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return stored === 'dark' || stored === 'system' ? stored : 'light';
+  } catch {
+    return 'light';
+  }
+}
+
+export function setStoredTheme(theme: Theme): void {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // Storage can be unavailable or restricted in some environments; theme still applies for the session.
+  }
+}

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -6,11 +6,10 @@ import ReactDOM from 'react-dom/client';
 import { HashRouter } from './lib/router';
 import { App } from './App';
 import { WorkspaceProvider } from './state/WorkspaceContext';
+import { getStoredTheme } from './lib/theme';
 import './styles/global.css';
 
-const storedTheme = window.localStorage.getItem('outreachr.theme');
-document.documentElement.dataset.theme =
-  storedTheme === 'dark' || storedTheme === 'system' ? storedTheme : 'light';
+document.documentElement.dataset.theme = getStoredTheme();
 
 const root = document.getElementById('root');
 

--- a/apps/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -19,6 +19,7 @@ import {
   Upload,
 } from 'lucide-react';
 import { useLocation, useNavigate } from '../lib/router';
+import { getStoredTheme, setStoredTheme } from '../lib/theme';
 import type { AgentProvider, ConnectorProvider, SuppressionItem } from '../../../shared/contracts';
 import {
   Badge,
@@ -1103,16 +1104,13 @@ export function SettingsPage(): React.JSX.Element {
   const [roundStatus, setRoundStatus] = useState<'planning' | 'active' | 'paused' | 'closed'>(
     'active',
   );
-  const [theme, setTheme] = useState<'light' | 'dark' | 'system'>(() => {
-    const stored = window.localStorage.getItem('outreachr.theme');
-    return stored === 'dark' || stored === 'system' ? stored : 'light';
-  });
+  const [theme, setTheme] = useState<'light' | 'dark' | 'system'>(getStoredTheme);
   const encryptionAvailable = useMemo(
     () => data?.connectors.every((item) => item.encryptionAvailable) ?? false,
     [data],
   );
   useEffect(() => {
-    window.localStorage.setItem('outreachr.theme', theme);
+    setStoredTheme(theme);
     document.documentElement.dataset.theme = theme;
   }, [theme]);
   if (!data) return <></>;


### PR DESCRIPTION
## Summary
- Reading/writing the theme preference via `window.localStorage` in `main.tsx` and `SettingsPage.tsx` had no error handling, and the read logic was duplicated in both files.
- Under Node >=25 (Web Storage API, release candidate as of Node 25, enabled by default without `--localstorage-file`), `globalThis.localStorage` resolves to a non-functional empty object instead of a real `Storage` instance, which crashes any renderer mount that reads the theme preference. This repo's `engines` field allows Node >=22.12.0 with no upper bound, so this is reproducible today for any contributor running Node 25+ locally, even though it doesn't trigger under the CI-pinned Node 22.23.2.
- Extracted the read/write logic into `apps/desktop/src/renderer/src/lib/theme.ts` (`getStoredTheme` / `setStoredTheme`) with try/catch fallbacks, so a missing or broken `localStorage` degrades to the `light` theme instead of crashing. Also removes the duplicated logic between `main.tsx` and `SettingsPage.tsx`.

## Test plan
- [x] `pnpm --filter @outreachr/desktop typecheck` passes
- [x] `pnpm -w run lint` passes (0 warnings)
- [x] Full test suite: 138/138 passing on Node 25.6.0 (previously 9 failing with `TypeError: window.localStorage.getItem is not a function` in `SettingsPage.tsx`, reproducible in isolation)
- [x] Verified `pnpm dev` boots the actual Electron app cleanly (main/preload/renderer build succeeds, no localStorage-related errors in console)

Note: this fix targets contributor/local-dev robustness under newer Node versions rather than a CI regression, since CI is pinned to Node 22.23.2 where this doesn't reproduce.