### PR TITLE
fix(cloud): keep workspace work available during Gmail interruptions

### DIFF
--- a/apps/cloud/src/runtime.ts
+++ b/apps/cloud/src/runtime.ts
@@ -36,6 +36,13 @@ const OPTIONAL_MAILBOX_ERRORS = new Set([
   'eliza_permission_required',
   'eliza_request_unconfirmed',
 ]);
+const PROVIDER_COMMANDS = new Set<keyof CommandMap>([
+  'draft.send',
+  'connector.test',
+  'connector.syncCalendar',
+  'connector.syncMail',
+  'meeting.create',
+]);
 const ADMIN_COMMANDS = new Set<keyof CommandMap>([
   'onboarding.complete',
   'communications.policy.update',
@@ -130,7 +137,7 @@ export class CloudRuntime {
         const mailbox = await this.mailboxes
           .current(session.userId, orgId, session.grant, client)
           .catch((error: unknown) => {
-            // CRM reads need workspace authority, not a working Gmail connection.
+            // Allow local workspace work when the selected Gmail connection is unavailable.
             // Never reuse unconfirmed mailbox credentials or suppress authentication/DB errors.
             if (
               mailboxAccess === 'optional' &&
@@ -244,6 +251,9 @@ export class CloudRuntime {
     payload: unknown,
     emit?: (event: AgentEvent) => void,
   ): Promise<CommandResultMap[K]> {
+    const manualMeeting =
+      name === 'meeting.create' &&
+      z.object({ provider: z.literal('manual') }).safeParse(payload).success;
     requireCondition(
       !NATIVE_COMMANDS.has(name),
       400,
@@ -324,7 +334,7 @@ export class CloudRuntime {
         return result;
       },
       emit,
-      READ_COMMANDS.has(name) ? 'optional' : 'required',
+      PROVIDER_COMMANDS.has(name) && !manualMeeting ? 'required' : 'optional',
     );
   }
 }

--- a/apps/cloud/src/runtime.ts
+++ b/apps/cloud/src/runtime.ts
@@ -30,6 +30,12 @@ const READ_COMMANDS = new Set<keyof CommandMap>([
   'contribution.export',
   'agent.detect',
 ]);
+const OPTIONAL_MAILBOX_ERRORS = new Set([
+  'mailbox_changed',
+  'google_account_setup_required',
+  'eliza_permission_required',
+  'eliza_request_unconfirmed',
+]);
 const ADMIN_COMMANDS = new Set<keyof CommandMap>([
   'onboarding.complete',
   'communications.policy.update',
@@ -114,13 +120,26 @@ export class CloudRuntime {
     orgId: string,
     work: (context: RuntimeContext, command: CommandService) => Promise<T>,
     emit: (event: AgentEvent) => void = () => {},
+    mailboxAccess: 'required' | 'optional' = 'required',
   ) {
     return withWorkspaceLock(this.options.pool, orgId, async (client) => {
       const organization = await memberOrganization(client, session.userId, orgId);
       const directory = await mkdtemp(join(tmpdir(), 'outreachr-cloud-'));
       let vault: VaultService | undefined;
       try {
-        const mailbox = await this.mailboxes.current(session.userId, orgId, session.grant, client);
+        const mailbox = await this.mailboxes
+          .current(session.userId, orgId, session.grant, client)
+          .catch((error: unknown) => {
+            // CRM reads need workspace authority, not a working Gmail connection.
+            // Never reuse unconfirmed mailbox credentials or suppress authentication/DB errors.
+            if (
+              mailboxAccess === 'optional' &&
+              error instanceof CloudError &&
+              OPTIONAL_MAILBOX_ERRORS.has(error.code)
+            )
+              return null;
+            throw error;
+          });
         const connectorId = mailbox
           ? mailboxConnectorId(mailbox.email)
           : `connector:cloud:unconnected:${session.userId}`;
@@ -204,10 +223,17 @@ export class CloudRuntime {
   }
 
   bootstrap(session: Session, identity: Identity, orgId: string) {
-    return this.withVault(session, identity, orgId, async (_context, command) => {
-      const data = await command.bootstrap();
-      return { ...data, hosting: 'cloud' as const, vaultPath: 'Cloud workspace' };
-    });
+    return this.withVault(
+      session,
+      identity,
+      orgId,
+      async (_context, command) => {
+        const data = await command.bootstrap();
+        return { ...data, hosting: 'cloud' as const, vaultPath: 'Cloud workspace' };
+      },
+      undefined,
+      'optional',
+    );
   }
 
   execute<K extends keyof CommandMap>(
@@ -298,6 +324,7 @@ export class CloudRuntime {
         return result;
       },
       emit,
+      READ_COMMANDS.has(name) ? 'optional' : 'required',
     );
   }
 }

--- a/apps/cloud/test/integration/workspaces.test.ts
+++ b/apps/cloud/test/integration/workspaces.test.ts
@@ -1427,6 +1427,37 @@ describe('managed Gmail end-to-end command flow', () => {
       (await runtime().bootstrap(session, user, org.id)).drafts.find((item) => item.id === draft.id)
         ?.providerMessageId,
     ).toBe('gmail-confirmed-receipt');
+    for (const state of ['disconnected', 'unavailable'] as const) {
+      mailboxState = state;
+      const offlineContact = await runtime().execute(session, user, org.id, 'person.create', {
+        firmId: firm.id,
+        name: `CRM ${state}`,
+        personalEmail: `${state}@example.test`,
+      });
+      expect(offlineContact.personalEmail).toBe(`${state}@example.test`);
+      const meeting = await runtime().execute(session, user, org.id, 'meeting.create', {
+        title: `Manual meeting ${state}`,
+        startsAt: '2026-09-10T12:00:00.000Z',
+        endsAt: '2026-09-10T13:00:00.000Z',
+        provider: 'manual',
+        investorId: firm.id,
+        personIds: [person.id],
+        location: null,
+        agenda: null,
+        notes: null,
+        status: 'upcoming',
+      });
+      expect(meeting.provider).toBe('manual');
+      await expect(
+        runtime().execute(session, user, org.id, 'draft.send', {
+          id: draft.id,
+          expectedContentHash: approved.contentHash,
+        }),
+      ).rejects.toMatchObject({
+        code: state === 'disconnected' ? 'mailbox_changed' : 'eliza_request_unconfirmed',
+      });
+      expect(sends).toBe(1);
+    }
     await pool.query(
       "UPDATE outreachr.organizations SET trial_ends_at=now()-interval '1 day' WHERE id=$1",
       [org.id],

--- a/apps/cloud/test/integration/workspaces.test.ts
+++ b/apps/cloud/test/integration/workspaces.test.ts
@@ -1308,12 +1308,18 @@ describe('managed Gmail end-to-end command flow', () => {
     const session = { userId: user.id, grant, expiresAt: new Date(Date.now() + 86400_000) };
     let sends = 0;
     let sentMime = '';
+    let mailboxState: 'connected' | 'disconnected' | 'unavailable' | 'unauthorized' = 'connected';
     const transport = new ElizaClient(
       delegationConfig('https://gmail.fixture.test'),
       async (url, init) => {
         expect(new Headers(init?.headers).get('X-App-Delegation')).toBe(grant);
         expect(new Headers(init?.headers).get('Authorization')).toMatch(/^Basic /);
-        if (String(url).endsWith('/google/connections'))
+        if (String(url).endsWith('/google/connections')) {
+          if (mailboxState === 'disconnected') return Response.json({ success: true, data: [] });
+          if (mailboxState === 'unauthorized')
+            return Response.json({ error: 'Unauthorized' }, { status: 401 });
+          if (mailboxState === 'unavailable')
+            return Response.json({ error: 'Unavailable' }, { status: 503 });
           return Response.json({
             success: true,
             data: [
@@ -1330,6 +1336,7 @@ describe('managed Gmail end-to-end command flow', () => {
               },
             ],
           });
+        }
         const operation = JSON.parse(String(init!.body));
         expect(operation.connectionId).toBe(connectionId);
         const endpoint = new URL(operation.url);
@@ -1420,5 +1427,41 @@ describe('managed Gmail end-to-end command flow', () => {
       (await runtime().bootstrap(session, user, org.id)).drafts.find((item) => item.id === draft.id)
         ?.providerMessageId,
     ).toBe('gmail-confirmed-receipt');
+    await pool.query(
+      "UPDATE outreachr.organizations SET trial_ends_at=now()-interval '1 day' WHERE id=$1",
+      [org.id],
+    );
+    for (const state of ['disconnected', 'unavailable'] as const) {
+      mailboxState = state;
+      const readable = await runtime().bootstrap(session, user, org.id);
+      expect(readable.drafts.find((item) => item.id === draft.id)?.providerMessageId).toBe(
+        'gmail-confirmed-receipt',
+      );
+      const output = await runtime().execute(session, user, org.id, 'data.exportCsv', {
+        directory: 'cloud-downloads',
+        kind: 'people',
+      });
+      const exported = await new FileStore(pool).get(user.id, org.id, output.path);
+      expect(exported.content.toString()).toContain('recipient@example.test');
+      await expect(
+        runtime().execute(session, user, org.id, 'draft.send', {
+          id: draft.id,
+          expectedContentHash: approved.contentHash,
+        }),
+      ).rejects.toThrow();
+      expect(sends).toBe(1);
+    }
+    mailboxState = 'unauthorized';
+    await expect(runtime().bootstrap(session, user, org.id)).rejects.toMatchObject({
+      code: 'eliza_authorization_expired',
+    });
+    mailboxState = 'connected';
+    await expect(
+      runtime().execute(session, user, org.id, 'person.create', {
+        firmId: firm.id,
+        name: 'No expired editing',
+        personalEmail: 'blocked@example.test',
+      }),
+    ).rejects.toMatchObject({ code: 'editing_seat_required' });
   }, 120_000);
 });


### PR DESCRIPTION
A disconnected Gmail account or temporary Google connection lookup failure blocked every vault operation, including ordinary CRM edits, manual meetings and read/export access after subscription expiry.

Workspace operations now continue without a connector when the selected mailbox is unavailable. Mail sending, synchronization, connection testing and provider-backed meeting creation retain strict mailbox validation. The fallback preserves the saved mailbox selection, uses no unconfirmed mailbox credential, and does not swallow expired Cloud authorization or database failures. Workspace membership and subscription checks still apply.

Validation:
- Reproduced the original failure before the fix with a disconnected selected mailbox.
- The real PostgreSQL/Gmail fixture verifies active CRM edits and manual meetings, blocked provider actions, persisted send receipts and CSV export after trial expiry, no extra sends, rejection of expired Cloud authorization, and denial of expired editing. It covers both disconnected and unavailable mailboxes.
- All 67 PostgreSQL integration tests passed; the complete browser flow passed in 24.7 seconds.
- Cloud types, focused lint and formatting passed. All final-head hosted checks passed on `821826ad3a10a62733dd0c82b6e2aabcd7bd5e97`: Cloud/browser, restricted-role Docker startup/isolation, CodeQL, quality/security, and all six native builds, Electron tests and packaged-app checks. PR attestation is intentionally skipped.

Real Gmail delivery and production deployment remain part of the release acceptance work.
