### PR TITLE
fix(cloud): allow payment setup for existing trials

### DIFF
--- a/apps/cloud-web/test/workspace.spec.ts
+++ b/apps/cloud-web/test/workspace.spec.ts
@@ -141,12 +141,22 @@ test('signs in, persists Shaw fixture contact and draft, runs a proposal, export
   await page.getByRole('button', { name: 'Review subscription', exact: true }).click();
   const billingReview = page.getByLabel('Subscription review', { exact: true });
   await expect(billingReview).toContainText('$49.00 per month before tax');
-  await expect(billingReview).toContainText('Quoted amount due now: $0.00');
+  await expect(billingReview).toContainText('Your existing trial ends');
+  await expect(billingReview).not.toContainText('Quoted amount due now');
   await page.getByRole('button', { name: 'Dismiss review', exact: true }).click();
   await expect(billingReview).toHaveCount(0);
   await page.getByRole('button', { name: 'Review subscription', exact: true }).click();
   await page.getByRole('button', { name: 'Agree and continue', exact: true }).click();
   await expect(page.getByRole('alert')).toContainText('Cloud has not confirmed this request');
+  await page.getByRole('button', { name: 'Check billing request', exact: true }).click();
+  await expect(page.getByRole('link', { name: 'Continue to checkout', exact: true })).toBeVisible();
+  // The provider fixture completes the original setup; the app must recover rather than repurchase.
+  const completedSetup = await page.request.post(
+    'http://127.0.0.1:4175/test/billing/setup-complete',
+  );
+  expect(completedSetup.ok()).toBe(true);
+  expect(await completedSetup.json()).toMatchObject({ count: 1 });
+  await page.reload();
   await page.getByRole('button', { name: 'Check billing request', exact: true }).click();
   await expect(
     page.getByRole('status').filter({ hasText: 'Cloud confirmed the billing request' }),

--- a/apps/cloud/src/billing.ts
+++ b/apps/cloud/src/billing.ts
@@ -386,7 +386,22 @@ export class BillingStore {
           quantity: selected.seats,
         };
         request = { ...selection, billingConsent: 'accepted' };
-        if (snapshot.mutationRevision !== null) {
+        const subscription = snapshot.subscription;
+        const paymentSetup =
+          subscription !== null &&
+          (subscription.status === 'trialing' || subscription.status === 'paused') &&
+          subscription.planRevisionId === selected.planRevisionId &&
+          subscription.quantity === selected.seats;
+        requireCondition(
+          subscription?.status !== 'paused' || paymentSetup,
+          409,
+          'billing_resume_terms_required',
+          'Resume the existing plan with its current seat count before changing the subscription.',
+        );
+        if (paymentSetup && subscription.status === 'trialing')
+          review.trialEndsAt = subscription.trial?.endsAt ?? null;
+        // Adding a card uses the existing trial's setup Checkout; quotes change its plan or seats.
+        if (snapshot.mutationRevision !== null && !paymentSetup) {
           const parsed = quoteSchema.safeParse(
             await api.quoteSubscriptionUpdate(binding.billingAccountId, this.productFamilyKey, {
               ...selection,

--- a/apps/cloud/test/browser-server.ts
+++ b/apps/cloud/test/browser-server.ts
@@ -433,7 +433,7 @@ fixture.get('/api/v1/apps/:appId/billing/accounts/:accountId/subscriptions/works
   });
 });
 // Exercise purchaser review and ambiguous recovery with generic Cloud SDK routes.
-const purchaseReceipts = new Map<string, { body: string; operation: unknown }>();
+const purchaseReceipts = new Map<string, { body: string; operation: AppBillingOperation }>();
 fixture.get(`/api/v1/apps/${appId}/billing/catalog`, (c) =>
   c.json({
     success: true,
@@ -497,7 +497,7 @@ fixture.post(
   },
 );
 fixture.post(
-  `/api/v1/apps/${appId}/billing/accounts/${billingAccountId}/subscriptions/workspace/update`,
+  `/api/v1/apps/${appId}/billing/accounts/${billingAccountId}/subscriptions/workspace/checkout`,
   async (c) => {
     if (grants.get(c.req.header('X-App-Delegation') ?? '')?.id !== owner.id)
       return c.json({ error: 'Owner required' }, 403);
@@ -507,8 +507,12 @@ fixture.post(
       billingConsent: string;
       quantity: number;
       planRevisionId: string;
+      expectedSubscriptionRevision: string;
+      quoteId?: string;
     };
     if (
+      input.expectedSubscriptionRevision !== '1' ||
+      input.quoteId !== undefined ||
       input.billingConsent !== 'accepted' ||
       input.quantity !== 1 ||
       input.planRevisionId !== billingPlanRevisionId
@@ -527,14 +531,29 @@ fixture.post(
         billingAccountId,
         productFamilyKey: 'workspace',
         environment: 'test',
-        status: 'succeeded',
-        subscriptionRevision: '1',
+        status: 'requires_action',
+        action: {
+          kind: 'checkout',
+          url: 'https://checkout.stripe.com/c/pay/setup-fixture',
+          expiresAt: null,
+        },
       },
     });
     return c.json({ error: 'Fixture lost response after commit' }, 503);
   },
 );
 // Local-only fixture controls; providerRequest forbids external network use.
+fixture.post('/test/billing/setup-complete', (c) => {
+  if (purchaseReceipts.size !== 1) return c.json({ error: 'One original setup required' }, 409);
+  const receipt = purchaseReceipts.values().next().value!;
+  if (
+    receipt.operation.status !== 'requires_action' ||
+    receipt.operation.action.kind !== 'checkout'
+  )
+    return c.json({ error: 'Original setup not pending' }, 409);
+  receipt.operation = { ...receipt.operation, status: 'succeeded', subscriptionRevision: '1' };
+  return c.json({ count: purchaseReceipts.size, operationId: receipt.operation.id });
+});
 const expiryReceipts = new Map<string, { body: string; operation: AppBillingOperation }>();
 fixture.post('/test/billing/external-checkout', (c) => {
   externalCheckout = {
@@ -560,6 +579,8 @@ fixture.get(
       return c.json({ error: 'Owner required' }, 403);
     const id = c.req.param('operationId');
     for (const receipt of trialReceipts.values())
+      if (receipt.operation.id === id) return c.json({ success: true, data: receipt.operation });
+    for (const receipt of purchaseReceipts.values())
       if (receipt.operation.id === id) return c.json({ success: true, data: receipt.operation });
     if (externalCheckout?.id === id) return c.json({ success: true, data: externalCheckout });
     for (const receipt of expiryReceipts.values())

--- a/apps/cloud/test/integration/billing-purchases.test.ts
+++ b/apps/cloud/test/integration/billing-purchases.test.ts
@@ -28,7 +28,10 @@ const identity = () => ({
   name: 'Buyer fixture',
   emailVerified: true,
 });
-async function fixture(active = false) {
+async function fixture(
+  active = false,
+  subscriptionStatus: 'active' | 'trialing' | 'paused' = 'active',
+) {
   const owner = identity(),
     viewer = identity();
   const workspaces = new WorkspaceStore(pool);
@@ -101,7 +104,10 @@ async function fixture(active = false) {
       expect(headers.get('X-App-Delegation')).toBe('buyer-grant');
     } else expect(headers.get('Authorization')).toBeNull();
     expect(headers.has('X-Eliza-Developer-Authorization')).toBe(false);
-    const endsAt = new Date(Date.now() + 86400_000).toISOString();
+    const endsAt = new Date(
+      Date.now() + (subscriptionStatus === 'paused' ? -1000 : 86400_000),
+    ).toISOString();
+    const trialStartedAt = new Date(Date.parse(endsAt) - 7 * 86400_000).toISOString();
     if (path.pathname.endsWith('/catalog'))
       return Response.json({
         success: true,
@@ -155,11 +161,15 @@ async function fixture(active = false) {
                 planRevisionId,
                 planKey: 'sol',
                 revision: '8',
-                status: 'active',
+                status: subscriptionStatus,
                 quantity: 1,
-                currentPeriodStart: new Date(Date.now() - 1000).toISOString(),
+                currentPeriodStart:
+                  subscriptionStatus === 'active'
+                    ? new Date(Date.now() - 1000).toISOString()
+                    : trialStartedAt,
                 currentPeriodEnd: endsAt,
-                trial: null,
+                trial:
+                  subscriptionStatus === 'active' ? null : { startedAt: trialStartedAt, endsAt },
                 cancelAtPeriodEnd: false,
                 canceledAt: null,
               }
@@ -167,7 +177,7 @@ async function fixture(active = false) {
           entitlement: active
             ? {
                 sourceSubscriptionRevision: '8',
-                access: 'granted',
+                access: subscriptionStatus === 'paused' ? 'read_only' : 'granted',
                 featureKeys: [],
                 seatCapacity: 1,
                 assignedSeats: 1,
@@ -175,7 +185,10 @@ async function fixture(active = false) {
               }
             : null,
           allowances: [],
-          trialEligibility: { status: 'eligible' },
+          trialEligibility:
+            active && subscriptionStatus !== 'active'
+              ? { status: 'claimed', startedAt: trialStartedAt, endsAt }
+              : { status: 'eligible' },
         },
       });
     }
@@ -314,13 +327,19 @@ async function fixture(active = false) {
         id: state.operationId,
         status: 'requires_action',
         action: {
-          kind: path.pathname.endsWith('/portal') ? 'portal' : active ? 'payment' : 'checkout',
+          kind: path.pathname.endsWith('/portal')
+            ? 'portal'
+            : path.pathname.endsWith('/update')
+              ? 'payment'
+              : 'checkout',
           url: path.pathname.endsWith('/portal')
             ? 'https://billing.stripe.com/p/session/fixture'
-            : active
+            : path.pathname.endsWith('/update')
               ? 'https://invoice.stripe.com/i/fixture'
               : 'https://checkout.stripe.com/c/pay/fixture',
-          expiresAt: state.linkExpired ? '2000-01-01T00:00:00Z' : endsAt,
+          expiresAt: state.linkExpired
+            ? '2000-01-01T00:00:00Z'
+            : new Date(Date.now() + 86400_000).toISOString(),
         },
       };
       receipts.set(body.idempotencyKey, { body, operation });
@@ -570,11 +589,23 @@ it('retains and recovers an exact checkout expiry after commit/response loss acr
     f.store().current(f.owner.id, f.org.id, 'buyer-grant'),
     f.store().expireCheckout(f.owner.id, f.org.id, 'buyer-grant', review.review.id),
   ]);
-  expect(results[0]).toEqual(results[1]);
-  expect(results[0]).toMatchObject({
+  // A status read after the competing expiry commits correctly finds no pending request.
+  expect([null, results[1]]).toContainEqual(results[0]);
+  expect(results[1]).toMatchObject({
     state: 'complete',
     cancellationPending: false,
     operation: { status: 'failed', error: { code: 'APP_BILLING_CHECKOUT_EXPIRED' } },
+  });
+  const saved = (
+    await pool.query(
+      'SELECT state,cancellation_pending,operation_json FROM outreachr.cloud_billing_intents WHERE id=$1',
+      [review.review.id],
+    )
+  ).rows[0];
+  expect(saved).toEqual({
+    state: 'complete',
+    cancellation_pending: false,
+    operation_json: results[1].operation,
   });
   expect(new Set(f.state.expiryBodies).size).toBe(1);
   expect(f.state.expiryEffects).toBe(1);
@@ -640,4 +671,60 @@ it('requires a new explicit cancellation after a proven unexecuted expiry reject
   expect(f.state.expiryEffects).toBe(0);
   await f.store().expireCheckout(f.owner.id, f.org.id, 'buyer-grant', review.review.id);
   expect(f.state.expiryEffects).toBe(1);
+});
+
+it.each(['trialing', 'paused'] as const)(
+  'adds payment to the existing %s subscription and recovers the same consent after response loss',
+  async (status) => {
+    const f = await fixture(true, status);
+    const result = await f
+      .store()
+      .review(f.owner.id, f.org.id, 'buyer-grant', { plan: 'sol', seats: 1 });
+    expect(result.review).toMatchObject({
+      kind: 'checkout',
+      plan: 'sol',
+      seats: 1,
+      monthlyTotalCents: 4900,
+    });
+    expect(f.state.quoteReads).toBe(0);
+    f.state.lost = true;
+    await expect(
+      f.store().confirm(f.owner.id, f.org.id, 'buyer-grant', result.review.id),
+    ).rejects.toMatchObject({ code: 'billing_result_unconfirmed' });
+    f.state.lost = false;
+    const recovered = await f.store().current(f.owner.id, f.org.id, 'buyer-grant');
+    expect(recovered).toMatchObject({
+      state: 'pending',
+      operation: {
+        id: f.state.operationId,
+        status: 'requires_action',
+        action: { kind: 'checkout' },
+      },
+    });
+    expect(JSON.parse(f.state.bodies[0]!)).toMatchObject({
+      quantity: 1,
+      expectedSubscriptionRevision: '8',
+      billingConsent: 'accepted',
+    });
+    expect(JSON.parse(f.state.bodies[0]!)).not.toHaveProperty('quoteId');
+    expect(new Set(f.state.bodies).size).toBe(1);
+    expect(f.state.effects).toBe(1);
+    expect(f.state.quoteReads).toBe(0);
+  },
+);
+it('requires resuming the paused subscription before changing its seats', async () => {
+  const f = await fixture(true, 'paused');
+  await expect(f.review()).rejects.toMatchObject({ code: 'billing_resume_terms_required' });
+  expect(f.state.quoteReads).toBe(0);
+  expect(f.state.effects).toBe(0);
+  expect(
+    (await pool.query('SELECT id FROM outreachr.cloud_billing_intents WHERE org_id=$1', [f.org.id]))
+      .rowCount,
+  ).toBe(0);
+});
+it('keeps quoted seat changes during an unexpired trial', async () => {
+  const f = await fixture(true, 'trialing');
+  expect((await f.review()).review.kind).toBe('update');
+  expect(f.state.quoteReads).toBe(1);
+  expect(f.state.effects).toBe(0);
 });


### PR DESCRIPTION
## What changed

Owners adding a payment method to an existing trial were always sent to the subscription-update quote API. That could leave an unexpired trial without a payment method and prevented an expired, paused trial from reaching setup Checkout.

An unchanged trial plan and seat count now use Cloud's existing setup Checkout, preserving the subscription revision and durable purchase consent. Plan or seat changes during a trial still require a quote; paused subscriptions must resume their existing terms first. The existing trial end is shown during payment setup.

The PostgreSQL regressions cover both trial states, lost-response recovery with one purchase effect, and the unchanged quote path for seat changes. The cancellation concurrency assertion now permits a status read after cancellation has committed, while verifying the same persisted terminal operation and exactly one cancellation.

## Verification

- The new regression failed on main and passed with the fix.
- Local validation passed: 67 Cloud unit tests, 71 PostgreSQL integration tests, the complete browser flow (including original setup recovery after reload), Cloud typecheck, focused ESLint, formatting, and diff checks.
- Hosted full verification and native packaging checks must pass before merge.
- No credentials or private outreach data are included.
- This does not claim live paid access or production deployment; the separate generic Cloud resumption-invoice recovery issue still needs its provider acceptance run.

## External-action review

This changes purchaser routing to the existing generic Cloud setup Checkout. It does not introduce app-specific Stripe code, bypass recurring consent, or infer paid access from a redirect. Lost responses retain the original idempotency key and subscription revision.
