### PR TITLE
fix(cloud): recover setup invoice payment actions

### DIFF
--- a/apps/cloud-web/test/workspace.spec.ts
+++ b/apps/cloud-web/test/workspace.spec.ts
@@ -155,8 +155,22 @@ test('signs in, persists Shaw fixture contact and draft, runs a proposal, export
     'http://127.0.0.1:4175/test/billing/setup-complete',
   );
   expect(completedSetup.ok()).toBe(true);
-  expect(await completedSetup.json()).toMatchObject({ count: 1 });
+  const setupReceipt = await completedSetup.json();
+  expect(setupReceipt).toMatchObject({ count: 1 });
   await page.reload();
+  await page.getByRole('button', { name: 'Check billing request', exact: true }).click();
+  await expect(page.getByRole('link', { name: 'Complete payment', exact: true })).toHaveAttribute(
+    'href',
+    'https://invoice.stripe.com/i/resume-fixture',
+  );
+  await expect(page.getByRole('link', { name: 'Continue to checkout', exact: true })).toHaveCount(
+    0,
+  );
+  const completedPayment = await page.request.post(
+    'http://127.0.0.1:4175/test/billing/payment-complete',
+  );
+  expect(completedPayment.ok()).toBe(true);
+  expect(await completedPayment.json()).toEqual(setupReceipt);
   await page.getByRole('button', { name: 'Check billing request', exact: true }).click();
   await expect(
     page.getByRole('status').filter({ hasText: 'Cloud confirmed the billing request' }),

--- a/apps/cloud/src/billing.ts
+++ b/apps/cloud/src/billing.ts
@@ -579,7 +579,7 @@ export class BillingStore {
           (intent.kind === 'portal'
             ? operation.action.kind === 'portal'
             : intent.kind === 'checkout'
-              ? operation.action.kind === 'checkout'
+              ? operation.action.kind === 'checkout' || operation.action.kind === 'payment'
               : intent.kind === 'update' && operation.action.kind === 'payment')),
       502,
       'billing_operation_scope',

--- a/apps/cloud/test/browser-server.ts
+++ b/apps/cloud/test/browser-server.ts
@@ -551,6 +551,21 @@ fixture.post('/test/billing/setup-complete', (c) => {
     receipt.operation.action.kind !== 'checkout'
   )
     return c.json({ error: 'Original setup not pending' }, 409);
+  receipt.operation = {
+    ...receipt.operation,
+    action: {
+      kind: 'payment',
+      url: 'https://invoice.stripe.com/i/resume-fixture',
+      expiresAt: new Date(Date.now() + 86400_000).toISOString(),
+    },
+  };
+  return c.json({ count: purchaseReceipts.size, operationId: receipt.operation.id });
+});
+fixture.post('/test/billing/payment-complete', (c) => {
+  if (purchaseReceipts.size !== 1) return c.json({ error: 'One original purchase required' }, 409);
+  const receipt = purchaseReceipts.values().next().value!;
+  if (receipt.operation.status !== 'requires_action' || receipt.operation.action.kind !== 'payment')
+    return c.json({ error: 'Original invoice not pending' }, 409);
   receipt.operation = { ...receipt.operation, status: 'succeeded', subscriptionRevision: '1' };
   return c.json({ count: purchaseReceipts.size, operationId: receipt.operation.id });
 });

--- a/apps/cloud/test/integration/billing-purchases.test.ts
+++ b/apps/cloud/test/integration/billing-purchases.test.ts
@@ -68,6 +68,7 @@ async function fixture(
     payDuringExpiry: false,
     expiryBodies: [] as string[],
     externalOperation: null as Record<string, unknown> | null,
+    recoveredOperation: null as Record<string, unknown> | null,
     reads: 0,
     quoteReads: 0,
     lost: false,
@@ -273,6 +274,8 @@ async function fixture(
             },
           },
         });
+      if (state.recoveredOperation && !state.settled)
+        return Response.json({ success: true, data: state.recoveredOperation });
       if (state.externalOperation && !state.settled)
         return Response.json({ success: true, data: state.externalOperation });
       expect(path.pathname.endsWith(state.operationId)).toBe(true);
@@ -728,3 +731,81 @@ it('keeps quoted seat changes during an unexpired trial', async () => {
   expect(f.state.quoteReads).toBe(1);
   expect(f.state.effects).toBe(0);
 });
+
+it('recovers the original setup checkout as an invoice payment action without new consent', async () => {
+  const f = await fixture(true, 'paused');
+  const review = await f
+    .store()
+    .review(f.owner.id, f.org.id, 'buyer-grant', { plan: 'sol', seats: 1 });
+  await f.store().confirm(f.owner.id, f.org.id, 'buyer-grant', review.review.id);
+  f.state.recoveredOperation = {
+    ...f.scope,
+    id: f.state.operationId,
+    status: 'requires_action',
+    action: {
+      kind: 'payment',
+      url: 'https://invoice.stripe.com/i/resume',
+      expiresAt: new Date(Date.now() + 86400_000).toISOString(),
+    },
+  };
+  expect(await f.store().current(f.owner.id, f.org.id, 'buyer-grant')).toMatchObject({
+    state: 'pending',
+    operation: { id: f.state.operationId, action: { kind: 'payment' } },
+  });
+  await expect(
+    f.store().expireCheckout(f.owner.id, f.org.id, 'buyer-grant', review.review.id),
+  ).rejects.toMatchObject({ code: 'checkout_not_open' });
+  expect(f.state.expiryEffects).toBe(0);
+  f.state.settled = true;
+  expect(await f.store().current(f.owner.id, f.org.id, 'buyer-grant')).toMatchObject({
+    state: 'complete',
+    operation: { id: f.state.operationId, status: 'succeeded' },
+  });
+  expect(f.state.effects).toBe(1);
+  expect(f.state.quoteReads).toBe(0);
+});
+
+it.each(['foreign operation', 'foreign account', 'unsafe URL', 'portal action'] as const)(
+  'rejects a setup recovery with %s and retains the original operation',
+  async (invalid) => {
+    const f = await fixture(true, 'paused');
+    const review = await f
+      .store()
+      .review(f.owner.id, f.org.id, 'buyer-grant', { plan: 'sol', seats: 1 });
+    await f.store().confirm(f.owner.id, f.org.id, 'buyer-grant', review.review.id);
+    f.state.recoveredOperation = {
+      ...f.scope,
+      id: invalid === 'foreign operation' ? randomUUID() : f.state.operationId,
+      billingAccountId: invalid === 'foreign account' ? randomUUID() : f.scope.billingAccountId,
+      status: 'requires_action',
+      action: {
+        kind: invalid === 'portal action' ? 'portal' : 'payment',
+        url:
+          invalid === 'unsafe URL'
+            ? 'https://attacker.example/invoice'
+            : invalid === 'portal action'
+              ? 'https://billing.stripe.com/p/session/fixture'
+              : 'https://invoice.stripe.com/i/resume',
+        expiresAt: new Date(Date.now() + 86400_000).toISOString(),
+      },
+    };
+    await expect(f.store().current(f.owner.id, f.org.id, 'buyer-grant')).rejects.toMatchObject({
+      code: invalid === 'unsafe URL' ? 'billing_operation_invalid' : 'billing_operation_scope',
+    });
+    const saved = (
+      await pool.query(
+        'SELECT operation_json,state FROM outreachr.cloud_billing_intents WHERE id=$1',
+        [review.review.id],
+      )
+    ).rows[0];
+    expect(saved).toMatchObject({
+      state: 'pending',
+      operation_json: { id: f.state.operationId, action: { kind: 'checkout' } },
+    });
+    f.state.recoveredOperation = null;
+    expect(await f.store().current(f.owner.id, f.org.id, 'buyer-grant')).toMatchObject({
+      operation: { id: f.state.operationId, action: { kind: 'checkout' } },
+    });
+    expect(f.state.effects).toBe(1);
+  },
+);


### PR DESCRIPTION
Resuming an existing subscription can advance its Checkout operation to a hosted invoice payment action. Outreachr rejected that valid response as a different billing request, leaving the purchaser unable to complete payment. Accept both action types for the original checkout intent while retaining operation identity, account/environment scope, Stripe URL validation and checkout-only expiration.

Validation: the new recovery regression failed before the fix; all 76 PostgreSQL integration tests now pass, including foreign operation/account, unsafe URL and portal rejection. The full browser flow verifies response-loss recovery, original Checkout-to-invoice transition and completion with one purchase receipt. Typecheck, ESLint and formatting pass.

The generic Cloud paid-invoice status correction and production deployment are separate work; this PR changes only Outreachr's consumer handling.
