### PR TITLE
docs(cloud): define app registration manifest

### DIFF
--- a/apps/cloud/README.md
+++ b/apps/cloud/README.md
@@ -32,9 +32,18 @@ contract and remaining acceptance checks are in
 1. Merge and deploy the generic Cloud app subscription and delegation APIs
    through that repository's migration, staging certification, and production
    approval workflow. Adopt the finalized consumer contract before cutover.
-2. Register Outreachr with its exact HTTPS origin and requested Google
-   capabilities. Use app-scoped credentials issued by Cloud. Provider tokens
-   remain in Cloud; the BFF stores only encrypted delegated grants.
+2. Use `registration.manifest.json` for the exact public origin, callback URIs,
+   requested scopes, billing return and separate test/live registration bodies.
+   The current app owner registers a confidential client through
+   `POST /api/v1/apps/{appId}/delegation-clients`. Save the returned client ID and
+   one-time `clientSecret` as `ELIZA_DELEGATION_CLIENT_ID` and `ELIZA_CLIENT_SECRET`.
+   A locally generated client secret does not establish a Cloud registration.
+   Provider tokens remain in Cloud; the BFF stores only encrypted delegated grants.
+   The manifest's null outputs must be resolved from the authorized registration
+   and operator configuration before deployment; the file itself is not proof of
+   registration. Callback URLs use `https://outreachr.eliza.app`, where the Worker
+   proxies `/api` to Railway with the edge secret. Do not register the direct
+   Railway origin as an OAuth callback.
 3. Declare the Sol and Astra plans through Cloud's generic app billing setup:
    $49 and $200 per editing seat/month, with the agreed seven-day no-card trial.
    Cloud owns Stripe provisioning, intake, and payment verification. Outreachr
@@ -49,8 +58,8 @@ contract and remaining acceptance checks are in
    the BFF the administrative database credential.
 5. Deploy `apps/cloud/Dockerfile` to Railway with the settings in
    `apps/cloud/railway.toml` and variables listed in `.env.example`. Use a random
-   32-byte base64 session encryption key and independent random client and edge
-   secrets. `ELIZA_INFERENCE_API_KEY` must be a funded product-owned Cloud key.
+   32-byte base64 session encryption key, an independent random edge secret, and
+   the client secret issued by Cloud registration. `ELIZA_INFERENCE_API_KEY` must be a funded product-owned Cloud key.
    There is deliberately one BFF replica while cancellation uses an in-process
    run registry. Workspace persistence and send serialization are in PostgreSQL.
 6. Build the frontend and set Cloudflare Worker secrets `BFF_ORIGIN` and

--- a/apps/cloud/registration.manifest.json
+++ b/apps/cloud/registration.manifest.json
@@ -1,0 +1,108 @@
+{
+  "purpose": "Operator preparation only. No IDs, secrets, registration or deployment are asserted by this file. Only delegationClients entries are API request bodies.",
+  "app": {
+    "name": "Outreachr",
+    "app_url": "https://outreachr.eliza.app",
+    "allowed_origins": ["https://outreachr.eliza.app"],
+    "appId": null,
+    "ownerOrganizationId": null
+  },
+  "delegationEndpoint": "/api/v1/apps/{appId}/delegation-clients",
+  "delegationClients": {
+    "test": {
+      "billingEnvironment": "test",
+      "redirectUris": [
+        "https://outreachr.eliza.app/api/auth/callback",
+        "https://outreachr.eliza.app/api/google/callback"
+      ],
+      "allowedScopes": [
+        "identity",
+        "inference",
+        "billing:read",
+        "billing:write",
+        "google.basic_identity",
+        "google.gmail.triage",
+        "google.gmail.send",
+        "google.calendar.read",
+        "google.calendar.write"
+      ],
+      "billingReturnUrl": "https://outreachr.eliza.app/#/settings"
+    },
+    "live": {
+      "billingEnvironment": "live",
+      "redirectUris": [
+        "https://outreachr.eliza.app/api/auth/callback",
+        "https://outreachr.eliza.app/api/google/callback"
+      ],
+      "allowedScopes": [
+        "identity",
+        "inference",
+        "billing:read",
+        "billing:write",
+        "google.basic_identity",
+        "google.gmail.triage",
+        "google.gmail.send",
+        "google.calendar.read",
+        "google.calendar.write"
+      ],
+      "billingReturnUrl": "https://outreachr.eliza.app/#/settings"
+    }
+  },
+  "billingNotificationUrl": "https://outreachr.eliza.app/api/billing/notifications",
+  "catalogRequirements": {
+    "productFamilyKey": "workspace",
+    "billingModel": "monthly per editing seat; viewers free; one plan per workspace",
+    "plans": [
+      {
+        "key": "sol",
+        "amountCents": 4900,
+        "currency": "usd",
+        "interval": "month",
+        "intervalCount": 1,
+        "model": "openai/gpt-5.6-sol",
+        "allowanceUsd": "15",
+        "expiredAccess": "read_only"
+      },
+      {
+        "key": "astra",
+        "amountCents": 20000,
+        "currency": "usd",
+        "interval": "month",
+        "intervalCount": 1,
+        "model": "openai/gpt-6-astra",
+        "allowanceUsd": "70",
+        "expiredAccess": "read_only"
+      }
+    ],
+    "trial": {
+      "days": 7,
+      "paymentMethodRequired": false,
+      "allowanceUsd": "2",
+      "initialEditingSeats": 1
+    },
+    "allowanceScope": "fixed per workspace, never multiplied by seat count; operator funded; no automatic overage"
+  },
+  "deployment": {
+    "publicOrigin": "https://outreachr.eliza.app",
+    "privateBffOrigin": "https://outreachr-production.up.railway.app",
+    "railwayServiceId": "5fdf32dd-7e6c-410f-92af-8abe792a9f24",
+    "worker": "outreachr-web"
+  },
+  "operatorOutputs": {
+    "ELIZA_APP_ID": null,
+    "ELIZA_DELEGATION_CLIENT_ID": null,
+    "ELIZA_CLIENT_SECRET": null,
+    "ELIZA_PRODUCT_FAMILY_KEY": "workspace",
+    "ELIZA_BILLING_ENVIRONMENT": null,
+    "ELIZA_INFERENCE_API_KEY": null,
+    "ELIZA_BILLING_NOTIFICATION_KEYS": null
+  },
+  "constraints": [
+    "Cloud issues clientSecret once during registration; a pre-generated value does not register or authenticate the client.",
+    "Keep test and live client registrations and workspace histories separate.",
+    "Only the public Worker origin is an OAuth callback origin; the Railway BFF requires the edge secret.",
+    "Product plan names and prices belong to this app configuration; Cloud provides generic infrastructure.",
+    "Use the existing authorized Cloud Stripe merchant and a funded product-owned inference credential.",
+    "Store returned secrets in deployment secret stores, never in this manifest."
+  ]
+}


### PR DESCRIPTION
Prepare Outreachr’s app-owned registration manifest with exact Worker callback URLs, separate test/live confidential-client request bodies, billing return URL and Sol/Astra catalog requirements. IDs and credentials remain unresolved until Cloud issues them.

Correct deployment instructions that previously suggested generating a client secret locally: the BFF must use the one-time secret returned by Cloud registration. The Railway origin is the private BFF target; OAuth callbacks use the public Worker origin.

Validation: both test/live request bodies passed the actual registerAppClientSchema on generic Cloud source 8c7415125fbee76e4d9a3a9628bfc5c71b7be090; exact callback and billing return origins match the current app; product terms match the app requirements, formatting and diff checks pass. No registration, provider mutation or deployment is performed by these files.
