### PR TITLE
docs: align shipping notes with generic app billing

### DIFF
--- a/docs/app-billing-and-shipping-plan.md
+++ b/docs/app-billing-and-shipping-plan.md
@@ -1,6 +1,6 @@
 # App subscriptions on Eliza Cloud: Outreachr shipping plan
 
-Decision updated 2026-09-05 after clarifying the platform boundary. This supersedes the product-specific Cloud API design in `cloud-implementation-plan.md` and the earlier proposal to move Stripe into Outreachr.
+Decision and implementation status updated 2026-09-06. This supersedes the product-specific Cloud API design in `cloud-implementation-plan.md` and the earlier proposal to move Stripe into Outreachr.
 
 ## Commercial boundaries
 
@@ -31,22 +31,23 @@ Managed Google access also uses a generic registered-app delegation. The signed-
 - Preserve read/export access after expiry. Enforce seat capacity and the selected model on the server.
 - Current bounded AI allowance: $2 during trial, $15 per Sol workspace/month, $70 per Astra workspace/month, shared by its members with no automatic overage. These are app allowance settings, not representations of the operator's final Cloud invoice.
 
-## Source findings and implementation scope
+## Implemented consumer boundary
 
-The generic `app-auth/connect` and `app-auth/session` routes already support registered-app identity without a personal-agent subscription check. Existing app charge requests create one-time Stripe payments for credits; those payments do not implement recurring SaaS app subscriptions. The Cloud billing task is implementing the generic recurring subscription and delegation contracts.
+Outreachr uses the generic Cloud SDK for registered-app identity, delegated Google operations, app-scoped inference, and recurring subscriptions. It has no direct Stripe integration. Billing account resolution uses the generic `/billing/accounts/resolve` route.
 
-Outreachr's existing `apps/cloud/src/billing.ts` persists checkout attempts and reconciles paid state under PostgreSQL locks. Adapt it to Cloud's generic subscription authority, retaining timeout recovery, tenant checks, and fail-closed reconciliation. Remove old product-specific paths, client headers, and token assumptions from `apps/cloud/src/eliza.ts`. Keep provider credentials out of browser bundles and store delegated grants encrypted at rest.
+The consumer persists reviews and exact command bodies before submission, requires explicit purchase consent, and recovers the original command after an ambiguous response. Checkout setup alone does not grant paid access. A subsequent payment action remains visible until Cloud confirms the command, and workspace access follows the current authoritative snapshot. Open checkout cancellation also persists and recovers its original command.
 
-The already-merged product-specific Cloud bridge is temporary and must be replaced. Coordinate consumer adoption before removing its routes. The final Cloud source must contain no Outreachr-specific implementation, price names, environment bindings, or runtime schema dependencies. Handle applied database migration history safely; never rewrite a deployed migration without checking its state.
+Cloud-signed notifications invalidate the local projection; they do not grant access. Trial adoption retains existing deadlines. Membership and owner changes synchronize with Cloud authority, and paid seat changes do not refill or multiply the workspace allowance. See [trial and ownership cutover](cloud-migration/trial-and-ownership-cutover.md) for migration requirements.
 
-## Implementation and release sequence
+The vendored SDK is pinned to a source commit with a SHA-256 manifest in `vendor/`. That establishes artifact provenance, not availability of those APIs in production. The generic Cloud integration must complete its own migration, verification and deployment gates before the app can use it live. Historical product-specific migrations remain migration history; the final Cloud runtime must not depend on Outreachr-specific code.
 
-1. Freeze the two draft Google onboarding PRs while the Cloud task settles the typed generic contract. Remove the unmerged direct-Stripe edits from Outreachr.
-2. Adopt app registration, scoped credentials, delegation, Google operations, and subscription APIs in Outreachr. Declare the app's plans using Cloud's built-in provisioning path. Verify which credential pays for inference.
-3. Update local billing projections and trial migration to match the authoritative contract. Preserve existing data, trial timestamps, in-flight checkout recovery, and duplicate-send protection.
-4. Exercise the consumer against the real generic handlers as well as controlled failure fixtures. Confirm that a second app and a personal Eliza subscription cannot affect Outreachr entitlements.
-5. Complete repository verification and terminal hosted checks for the final commit, merge reviewed changes, then deploy through the existing Cloud and app release gates.
-6. Verify the deployed app using actual login, managed Google consent, both models, Stripe test-mode lifecycle, and a controlled approved email. A healthy container or mocked browser test is only intermediate evidence.
+## Remaining release sequence
+
+1. Complete the generic Cloud subscription and delegation integration, including lifecycle validation and its deployment gates. Confirm the deployed contract against the pinned consumer SDK.
+2. Resolve the operator account and app owner organization. Register the app and separate test/live confidential delegation clients using [the registration manifest](../apps/cloud/registration.manifest.json). Store issued credentials and notification keys in deployment secret stores. A locally generated secret is not a registered client credential.
+3. Provision the declared Sol and Astra plans through Cloud's generic billing setup, and configure a funded app-owned inference credential. Cloud owns the Stripe catalog and provider events.
+4. Apply the app schema and runtime-role permissions, deploy the verified BFF revision to Railway, and deploy the matching frontend and API proxy to Cloudflare. Follow [the deployment instructions](../apps/cloud/README.md#deployment).
+5. Exercise actual login, managed Google consent, both exact models, workspace isolation, and the Stripe test-mode lifecycle through the deployed app. Verify revision readback and provider outcomes. Complete the controlled email test once the sender postal address is supplied.
 
 ## Acceptance tests
 
@@ -58,43 +59,10 @@ The already-merged product-specific Cloud bridge is temporary and must be replac
 - Inference: execute both exact plan models with the operator's app credential; meter the workspace allowance and hold ambiguous reservations. The end user's personal plan or credit balance is not the payer.
 - Delivery: desktop regressions, full HTTP/browser/mobile flow, actual Linux container startup with least-privilege PostgreSQL, final revision readback, and confirmed provider results.
 
-## Current live prerequisites
+## Current verification and live prerequisites
 
-App registration and inference credentials have not been provisioned. The normal CLI login reached its authorization screen, but creation of its persistent key still awaits confirmation. Cloud Stripe test-mode access and a real sender postal address remain prerequisites for the final billing and email exercises. No live charge or email has been made as test evidence.
+The September 6 consumer validation passed 76 PostgreSQL integration tests, 67 unit tests, the complete browser fixture flow, type checking, the web build, lint, and the Worker deployment dry run. Direct computer-use checks additionally exercised trial recovery, subscription review, lost checkout response recovery, the setup-to-payment transition, and checkout cancellation recovery. These use local provider fixtures. See [the validation record](cloud-validation.md) for the evidence boundaries.
 
-## Generic delegation consumer verification, September 5
+Actual app registration, issued delegation credentials, notification keys and a funded inference credential remain outstanding. Railway CLI sign-in is confirmed, but the Outreachr service has no deployment. The Cloud dashboard restored an account different from the attempted sign-in account; ownership must be resolved before registration. A later browser readback reached a Cloud session gate whose offered reopen link returned the same gate; no current operator dashboard was recovered. The generic Cloud API integration is still undergoing central validation and is not asserted deployed here.
 
-An isolated consumer checkout now integrates the built generic Cloud SDK from
-source commit `d01cbcd49c0b2`. Artifact SHA-256:
-`960c10f3d76ff9a76bc2cd36ab173602ab0eabcaecc1f2391ba5c3b285387785`.
-The SDK is temporarily installed from a local tarball for verification only.
-Replace that dependency with an immutable released package before committing or deploying.
-
-Implemented consumer behavior:
-
-- Explicit app consent and registered auth and Google callback URIs.
-- Confidential Basic client authentication with server-only `X-App-Delegation` grants.
-- Verification of app ID, registration-pinned test/live environment, credential expiry,
-  identity capability and verified email. Free users need no Cloud organization for login.
-- Managed Google connection capabilities drive local connector permissions; no raw
-  provider scopes or credentials are assumed. Cloud checks every proxied operation.
-- Provider responses preserve receipts and pagination; ambiguous sends are not retried.
-
-Verification passed: 14 packaged-SDK contract tests through actual local HTTP,
-24 total cloud unit tests, 15 PostgreSQL integration tests and the complete browser
-fixture flow. The browser flow includes login, CRM and draft persistence, proposal
-review, Google connection and mailbox selection, export, and invited viewer isolation.
-Type checking and focused lint passed. These are controlled provider fixtures, not
-production or real email/payment acceptance.
-
-This is an intermediate migration. Generic delegated inference, signed Cloud
-notifications and authoritative snapshot refresh are now integrated. The
-purchaser adapter now uses the generic SDK with persisted review, explicit consent, and recovery of the original command. The old named billing endpoint is removed.
-Durable ordinary membership and seat activation are now integrated; owner
-transfers and original trial import remain incomplete. Authoritative usage
-reporting and Cloud allowance enforcement are now integrated locally. Existing trial deadlines and the explicit
-Review subscription flow must remain intact. No production deployment or release
-claim is valid until those pieces, immutable SDK packaging, hosted checks and live
-acceptance are complete.
-
-Cloud catalog allowance is fixed per billing account and period. Editing seat quantity affects recurring price and capacity only; proration and seat changes do not refill or multiply the allowance.
+A prior generic Cloud Stripe sandbox exercise confirmed one paid fixture invoice. It does not establish the deployed Outreachr plans, renewal, seat changes, refunds or cancellation. Those lifecycle outcomes still require acceptance against the final integrated Cloud revision. No live Outreachr email has been sent; the sender postal address remains required.

--- a/docs/cloud-implementation-plan.md
+++ b/docs/cloud-implementation-plan.md
@@ -35,8 +35,8 @@ Offer a seven-day, no-card trial on the default workspace, once per verified
 Eliza account. Trial expiry preserves access to read and export existing data;
 editing, generation, and sending require an active entitlement. Creating another
 workspace or accepting another invite does not reset a consumed trial. The trial
-includes a bounded AI allowance. Paid allowances are per seat and pooled within
-the workspace, shown alongside remaining usage. No automatic paid overages.
+includes a bounded AI allowance. Paid allowances are fixed per workspace and shared by its members, shown
+alongside remaining usage; editing seat quantity does not multiply them. No automatic paid overages.
 
 ## Verified reuse boundaries
 

--- a/docs/cloud-validation.md
+++ b/docs/cloud-validation.md
@@ -1,23 +1,34 @@
-# Outreachr Cloud validation — 2026-09-05
+# Outreachr Cloud validation — 2026-09-06
 
-The Cloud implementation is in the isolated `feat/outreachr-cloud` checkout. The companion Eliza integration is tracked by elizaOS/eliza#30598. This report records intermediate evidence, not completed live acceptance.
+This record separates consumer verification from deployed provider acceptance. The current consumer uses generic Cloud APIs; historical tests of the original product-specific bridge do not establish the generic integration.
 
-## Passing local checks
+## Verified consumer revision
 
-- Outreachr `pnpm verify`: formatting, lint, types, 358 tests, all package and application builds.
-- Real PostgreSQL integration: 13 passing tests, covering concurrent first login, one-time trials, membership and invitation authority, sessions, usage reservation, vault durability, files, reviewed AI proposals, billing replay/current-state reconciliation, and Gmail sends.
-- Browser E2E: real BFF and PostgreSQL with local identity and provider fixtures; sign-in, onboarding, Shaw fixture contact and draft persistence, AI proposal review, CSV download, viewer invitation acceptance, owner-only billing controls, and no serious/critical axe findings or renderer errors.
-- Managed Gmail test: real command/connector/vault path with selected `gmail.modify` connection, normalized mailbox identity, approval, persisted provider receipt, restart readback, and duplicate-send rejection. The Google response is a fixture; no real message was sent.
-- Stripe boundary: three tests use the real Stripe SDK with a controlled HTTP transport and actual webhook signing; wrong product/customer authority and tampered signatures fail.
-- Eliza delegation and PGlite migration tests pass. Migration replay preserves revoked token replay protection.
-- Frontend build and Cloudflare Worker deployment dry run pass.
+[PR #47](https://github.com/lalalune/outreachr/pull/47), head `9262e5b6f644df36f55942319a39570dce11939a`, corrects billing account resolution to `/billing/accounts/resolve` and pins the SDK artifact from Cloud source `58cbb4cae02dc578ca0197850818d7710ceb5b4b`. Its adjacent vendor manifest records the artifact hash and source provenance.
 
-## Live infrastructure readback
+Changing the provider fixtures to the canonical route exposed nine provisioning failures with the previous SDK. The corrected artifact passes:
 
-The existing Cloud PostgreSQL database now contains a separate `outreachr` schema. A new restricted `outreachr_runtime` role can perform product DML, cannot create schema objects, and receives PostgreSQL permission denied when attempting to read `public.users`. The BFF receives only this restricted credential. No Cloud user or billing records were changed.
+- 76 integration tests against disposable local PostgreSQL databases.
+- 67 cloud unit tests.
+- The complete browser fixture scenario, including identity, trial recovery, CRM and draft persistence, reviewed proposals, billing command recovery, payment actions, checkout cancellation, invitations, viewer isolation, export and mobile checks.
+- Cloud type checking, frontend build, focused lint and formatting, frozen-lockfile installation, and Cloudflare Worker deployment dry run.
 
-Shaw's Google login reached Cloud's dedicated-agent join page, which reported insufficient account credits. A full authenticated app registration and managed Gmail readback remain outstanding.
+Direct computer-use verification also confirmed pending trial restrictions, recovery of the existing trial, Sol seat pricing, recovery after a lost checkout response, payment setup without granting paid access, and checkout cancellation recovery with one cancellation receipt. The browser fixtures implement a one-seat payment scenario; the three-seat review display is not proof of a three-seat provider purchase.
 
-## Remaining acceptance
+Use GitHub's current checks for terminal hosted verification of this exact revision. Local checks, a source commit, and a Worker dry run are not deployment evidence.
 
-Hosted PR checks and merges; companion Cloud staging certification and production deployment; app registration and funded inference credential; Stripe product/webhook setup and test-mode lifecycle; Railway service and Cloudflare domain deployment; real Sol and Astra inference; real Gmail send and sent-mail readback. The sender postal address is still required from the user. Desktop E2E and final post-sync checks are running.
+## Infrastructure and provider boundaries
+
+Railway CLI authentication is confirmed. The configured Outreachr service has no deployment and still requires app registration, issued delegation credentials, billing environment and notification configuration, and a funded product-owned inference credential. Cloudflare publication and final frontend/BFF revision readback remain outstanding.
+
+Earlier database verification established a separate `outreachr` schema and restricted runtime role, including denial of reads from `public.users`. Recheck the deployed runtime permissions and migrations at cutover. Do not give the BFF the database administrator credential.
+
+The Cloud dashboard restored a session for a different account from the attempted operator sign-in. The app owner account and organization remain unresolved. A later browser readback reached a Cloud session gate whose offered reopen link returned the same gate; no current operator dashboard was recovered. The generic Cloud integration is undergoing separate central verification and deployment; the pinned SDK does not prove that its production routes are available.
+
+A prior generic Cloud Stripe sandbox exercise verified one paid fixture invoice. It did not use the deployed Outreachr Sol/Astra plans and does not establish complete lifecycle acceptance. Managed Gmail results in the consumer suite are fixtures; no live Outreachr email has been sent.
+
+## Remaining deployed acceptance
+
+Complete generic Cloud integration and deployment; app/client registration; catalog and notification setup; Railway and Cloudflare deployment; actual login and delegated Google consent; both exact model executions and app-funded allowance accounting; subscription independence from personal Eliza plans; and Stripe test-mode purchase, renewal, failure recovery, seat/plan changes, refunds and cancellation against the final integrated revision.
+
+Verify the controlled Gmail send with a provider receipt, sent-mail readback and duplicate-send rejection after the sender postal address is supplied. Keep fixture evidence and actual provider results distinct. Follow [the shipping plan](app-billing-and-shipping-plan.md) and [deployment instructions](../apps/cloud/README.md#deployment).


### PR DESCRIPTION
The shipping notes still described an uncommitted temporary SDK, unfinished consumer ownership/trial migration, and per-seat AI allowances. Align them with the generic billing consumer now merged in #47: a pinned SDK, durable billing recovery, preserved trials, and fixed per-workspace allowances.

Replace the historical bridge validation report with current consumer evidence and explicit remaining deployment/provider acceptance. App registration, operator identity, generic Cloud deployment, and live Outreachr lifecycle verification remain outstanding.

Validation: Prettier, `git diff --check`, and local documentation link resolution passed. Documentation only; no runtime change.
